### PR TITLE
ci: adopt reusable workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,65 +10,13 @@ permissions:
   contents: read
 
 jobs:
-  test-python:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.9", "3.10", "3.11"]
-
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -e ".[dev]"
-
-    - name: Lint with ruff
-      run: |
-        ruff check src tests
-
-    - name: Check formatting with black
-      run: |
-        black --check src tests
-
-    - name: Type check with mypy
-      run: |
-        mypy src
-
-    - name: Run tests
-      run: |
-        pytest --cov=apollo --cov-report=xml --cov-report=term
-
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
-      with:
-        file: ./coverage.xml
-        fail_ci_if_error: false
-
-  # Web dashboard CI will be added when webapp is implemented
-  # test-webapp:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - name: Set up Node.js
-  #     uses: actions/setup-node@v4
-  #     with:
-  #       node-version: '18'
-  #   - name: Install dependencies
-  #     run: |
-  #       cd webapp
-  #       npm ci
-  #   - name: Run tests
-  #     run: |
-  #       cd webapp
-  #       npm test
-  #   - name: Build
-  #     run: |
-  #       cd webapp
-  #       npm run build
+  standard:
+    uses: c-daly/logos/.github/workflows/reusable-standard-ci.yml@main
+    with:
+      python_versions: '["3.9","3.10","3.11"]'
+      python_lint_paths: 'src tests'
+      mypy_targets: 'src'
+      pytest_command: 'pytest --cov=apollo --cov-report=xml --cov-report=term'
+      coverage_python_version: '3.11'
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- switch .github/workflows/ci.yml to the shared reusable-standard-ci workflow so Apollo matches the LOGOS baseline
- keep the existing python matrix (3.9-3.11), lint/type/test commands, and Codecov upload via template inputs

## Testing
- workflow only

Closes #35.