### PR TITLE
docs: capture CI parity commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,29 @@ Running `pip install -e .` (or `pip install -e ".[dev]"`) will automatically pul
 3. Commit the regenerated SDKs inside `logos`, then bump the `git+https://...` commit hashes in `pyproject.toml` here so Poetry picks up the new artifacts.
 4. `poetry lock --no-update && poetry install` (or `pip install -e .`) to refresh your virtualenv.
 
+## Local Testing (CI Parity)
+
+Apollo’s `.github/workflows/ci.yml` invokes the reusable LOGOS workflow plus the webapp job. Run the same commands locally before opening a PR:
+
+```bash
+# Python CLI
+python -m pip install --upgrade pip
+pip install -e ".[dev]"
+ruff check src tests
+black --check src tests
+mypy src
+pytest --cov=apollo --cov-report=term --cov-report=xml
+
+# Web dashboard
+cd webapp
+npm install
+npm run lint
+npm run type-check
+npm run test -- --run
+```
+
+Keeping these commands green locally mirrors the CI signal.
+
 ### Running the Web Dashboard
 
 ```bash

--- a/docs/ci/WORKFLOW_INVENTORY.md
+++ b/docs/ci/WORKFLOW_INVENTORY.md
@@ -44,7 +44,23 @@ Legend: ✅ = covered, ⚠️ = partially covered or manual, ❌ = missing.
 - `ci.yml`: Ruff/Black/mypy, pytest with 95% coverage gate, Codecov upload only for Python 3.12.
 - **Gaps:** no integration/e2e tests, workflow triggers only on `main`, so branches lack automatic feedback.
 
+## Standard Workflow Adoption (Nov 21 Update)
+
+| Repo | Template adoption | Notes |
+| --- | --- | --- |
+| logos | ✅ Template lives in `.github/workflows/reusable-standard-ci.yml`; existing `test.yml` remains bespoke for ontology gates. |
+| apollo | ✅ `ci.yml` consumes the template (pip) + Node overrides. |
+| sophia | ✅ Switched to the template with Poetry + the `-m "not integration"` pytest filter. |
+| hermes | ✅ Base lint/type/test job uses the template; package build + optional Milvus integration job remain custom. |
+| talos | ✅ Template drives Ruff/Black/mypy + the 95% coverage gate via Poetry. |
+
 ## Next Steps
-1. Finish review of this inventory with the team (issues #32/#33). Move the LOGOS doc to “PR awaiting merge” once accepted.
-2. Implement the shared workflow template (issue #294) and reference it from each repo (issue #295 + per-repo subtasks).
-3. Once the template lands, gradually enable stricter gates (mypy, coverage thresholds, integration toggles) per repo.
+1. Keep this inventory in sync with template changes (issues #32/#33). Move the LOGOS doc to “PR awaiting merge” once accepted.
+2. Track reusable workflow updates in issue #294 and mirror them with per-repo subtasks (issue #295 et al.).
+3. Use the template inputs to ratchet up gates (coverage thresholds, optional integration jobs) once each repo stabilizes.
+
+## Follow-up backlog
+
+- **Hermes:** Integration tests still depend on a manual label; file/track a follow-up to require them once Milvus/minio provisioning is faster.
+- **Talos:** Add a simulator/hardware smoke workflow when deterministic fixtures exist.
+- **Logos:** Run mypy inside `test.yml` (it's already installed) and publish Codecov summaries instead of raw XML artifacts.


### PR DESCRIPTION
## Summary
- document the exact commands developers should run locally so they match the reusable workflow
- update the CI inventory with a status table + backlog items

## Testing
- docs only