### PR TITLE
[apollo] Wire Hermes chat to persona diary

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,26 @@ apollo-cli chat "Draft a plan for tidying the lab" --provider openai --model gpt
 
 Both the CLI `chat` command and the Apollo web chat automatically pull the most recent persona-diary entries (default: 5) and prepend them to the Hermes system prompt so responses stay grounded in Sophia's latest beliefs/decisions. Use `--persona-limit` or `--no-persona` to tune that behaviour in the CLI.
 
+### Hermes LLM Gateway
+
+Hermes defaults to a deterministic `echo` provider so demos work without credentials. To hit a real model:
+
+1. Export provider credentials (OpenAI-compatible today):
+   ```bash
+   export HERMES_LLM_PROVIDER=openai
+   export HERMES_LLM_API_KEY=sk-...
+   export HERMES_LLM_MODEL=gpt-4o-mini
+   ```
+2. Start the gateway from the sibling repo:
+   ```bash
+   cd ../hermes
+   poetry install --with dev
+   poetry run hermes   # serves http://localhost:8080
+   ```
+3. Point Apollo at it (`VITE_HERMES_*` in `.env`, `hermes.*` in `config.yaml`).
+
+See [docs/HERMES_SETUP.md](docs/HERMES_SETUP.md) for a complete walkthrough, including verification commands and Milvus/ML extras.
+
 ### Shared SDK Clients
 
 Apollo CLI now depends exclusively on the generated Python SDKs that live in the [`logos`](https://github.com/c-daly/logos) repository:

--- a/docs/HERMES_SETUP.md
+++ b/docs/HERMES_SETUP.md
@@ -1,0 +1,116 @@
+# Hermes Setup Guide
+
+Hermes is the stateless LLM/embedding gateway for Project LOGOS. Apollo’s CLI and
+webapp talk to Hermes via the `/llm`, `/embed_text`, and diagnostics endpoints, so
+running Hermes with a real provider is the easiest way to get “production-like”
+behavior locally.
+
+## 1. Prerequisites
+
+- Python 3.11+
+- [Poetry](https://python-poetry.org/) 1.6+ (preferred) or a virtualenv with pip
+- (Optional) Docker if you want Milvus persistence
+- An API key for the upstream provider (OpenAI-compatible key for now)
+
+## 2. Configure a Provider
+
+Set the provider and credentials before launching Hermes. You can export them in
+your shell or place them in a `.env` file that your process manager loads.
+
+```bash
+export HERMES_LLM_PROVIDER=openai           # defaults to echo if omitted
+export HERMES_LLM_API_KEY=sk-...
+export HERMES_LLM_MODEL=gpt-4o-mini         # optional override
+# Optional: point to a compatible gateway (Azure, self-hosted, etc.)
+# export HERMES_LLM_BASE_URL=https://api.openai.com/v1
+```
+
+Hermes falls back to the deterministic `echo` provider if no credentials are
+present, so double-check `/health` for the active provider if responses look
+like loopbacks.
+
+## 3. Start Hermes
+
+From the sibling `hermes/` repository in this workspace:
+
+```bash
+cd ../hermes
+poetry install --with dev                   # one time
+poetry run hermes                           # serves on http://localhost:8080
+```
+
+> **Tip:** If you need the ML-heavy endpoints (Whisper, TTS, embeddings), install
+> the `ml` extras described in `hermes/README.md`. The `/llm` gateway only needs
+> the lightweight dependencies, so the default `poetry install --with dev`
+> remains fast.
+
+You should see logs like:
+
+```
+INFO:hermes.main:Hermes API startup complete
+INFO:     Uvicorn running on http://0.0.0.0:8080
+```
+
+Check health + provider:
+
+```bash
+curl http://localhost:8080/health
+```
+
+## 4. Point Apollo at Hermes
+
+### Webapp `.env`
+
+```env
+VITE_HERMES_API_URL=http://localhost:8080
+VITE_HERMES_API_KEY=                       # optional bearer token for Hermes
+VITE_HERMES_TIMEOUT=30000
+VITE_HERMES_LLM_PROVIDER=openai
+VITE_HERMES_LLM_MODEL=gpt-4o-mini
+VITE_HERMES_LLM_TEMPERATURE=0.2
+VITE_HERMES_LLM_MAX_TOKENS=512
+VITE_HERMES_SYSTEM_PROMPT=
+```
+
+### CLI `config.yaml`
+
+```yaml
+hermes:
+  host: localhost
+  port: 8080
+  timeout: 30
+  api_key: ""         # optional if Hermes itself is open
+  provider: openai
+  model: gpt-4o-mini
+  temperature: 0.2
+  max_tokens: 512
+  system_prompt: ""
+```
+
+## 5. Run the Apollo Stack
+
+1. Start Hermes (see above).
+2. Launch Apollo’s API + webapp:
+
+   ```bash
+   cd ../apollo
+   ./scripts/run_apollo.sh
+   ```
+
+3. Open `http://localhost:3000` (or the port you specified) and use the chat tab.
+
+When you send a chat prompt now:
+
+- The browser/CLI calls Hermes `/llm` with your configured provider/model.
+- Apollo persists the response to the persona diary (`POST /api/persona/entries`),
+  so Sophia’s Neo4j store keeps a record of the exchange.
+- Diagnostics telemetry reflects the real `/llm` latency and token usage.
+
+To confirm Sophia storage, open the Persona Diary tab or query via:
+
+```bash
+curl "http://localhost:8082/api/persona/entries?limit=5" | jq
+```
+
+You should see the chat turns recorded as `observation` entries with metadata
+that references the Hermes response IDs and provider details.

--- a/docs/PERSONA_LLM_INTEGRATION.md
+++ b/docs/PERSONA_LLM_INTEGRATION.md
@@ -96,6 +96,12 @@ The Apollo web chat now forwards every Hermes `/llm` invocation with a consisten
 
 Once Hermes responds, the webapp measures round-trip latency, extracts token usage, and attaches persona sentiment (if Hermes populates `raw.persona.sentiment`). That telemetry is POSTed to `POST /api/diagnostics/llm`, allowing the diagnostics panel to display live LLM latency, token counts, and persona sentiment next to the existing API/plan metrics.
 
+Finally, every successful chat turn is persisted to Sophia's persona diary via
+`POST /api/persona/entries`. The entry text equals the Hermes completion, the summary
+mirrors the latest user prompt, and the metadata block records the Hermes response ID,
+provider, and model. This keeps Neo4j/Sophia aligned with what the operator sees in
+the chat timeline.
+
 ### CLI Chat Command
 
 The new `apollo-cli chat "..."` command uses the same integration stack:
@@ -104,5 +110,6 @@ The new `apollo-cli chat "..."` command uses the same integration stack:
 2. Append a formatted “Persona diary context” block to the Hermes system prompt.
 3. Send metadata such as `persona_entry_ids`, entry-type/sentiment histograms, CLI version, and provider/model hints.
 4. Emit latency + token usage telemetry back to `POST /api/diagnostics/llm` so the dashboard mirrors CLI conversations just like browser chats.
+5. Persist each successful completion to `POST /api/persona/entries`, so Sophia's Neo4j store receives the same record the UI relies on.
 
 Provider/model/temperature/max-token overrides can be supplied via `config.yaml` (under `hermes.*`) or ad-hoc CLI flags. This keeps the CLI, browser, and diagnostics timelines in sync whenever Hermes is consulted.

--- a/docs/phase2/VERIFY.md
+++ b/docs/phase2/VERIFY.md
@@ -423,6 +423,7 @@ Tested and working on:
    - Hermes completion text + token usage + latency are displayed.
 2. Open the web chat panel, send a prompt, and ensure the UI also tags persona context in the system prompt (inspect network request metadata for `persona_entry_ids`).
 3. In both cases, verify `/api/diagnostics/llm` receives telemetry (telemetry tab should show LLM latency/tokens updating) and logs include the `surface` values `apollo-cli.chat` / `apollo-webapp.chat-panel`.
+4. Call `GET /api/persona/entries?limit=5` (or check the Persona Diary tab) and confirm new `observation` entries exist for each chat turn with `metadata.hermes_response_id` populated.
 
 ### Persona Diary
 - Timeline visualization

--- a/src/apollo/cli/main.py
+++ b/src/apollo/cli/main.py
@@ -585,6 +585,13 @@ def chat(
             latency_ms,
             llm_request.metadata or {},
         )
+        _log_persona_entry(
+            persona_client=persona_client,
+            prompt=prompt,
+            response_text=completion_text,
+            response_data=response.data,
+            metadata=llm_request.metadata or {},
+        )
     else:
         console.print("[red]✗ Hermes request failed[/red]")
         console.print(
@@ -679,6 +686,40 @@ def diary(
         )
 
 
+def _log_persona_entry(
+    *,
+    persona_client: PersonaClient,
+    prompt: str,
+    response_text: str,
+    response_data: Dict[str, Any],
+    metadata: Dict[str, Any],
+) -> None:
+    payload_metadata = _sanitize_metadata(
+        {
+            **metadata,
+            "prompt": prompt,
+            "hermes_response_id": response_data.get("id"),
+            "hermes_provider": response_data.get("provider"),
+            "hermes_model": response_data.get("model"),
+        }
+    )
+    entry_response = persona_client.create_entry(
+        content=response_text or "[Hermes returned an empty message]",
+        entry_type="observation",
+        summary=_truncate_summary(prompt),
+        sentiment=None,
+        confidence=None,
+        process=[],
+        goal=[],
+        emotion=[],
+        metadata=payload_metadata,
+    )
+    if not entry_response.success:
+        console.log(
+            f"[yellow]Warning:[/yellow] Failed to log persona entry: {entry_response.error}"
+        )
+
+
 def _fetch_persona_entries(
     persona_client: PersonaClient, limit: int
 ) -> List[Dict[str, Any]]:
@@ -761,6 +802,13 @@ def _sanitize_metadata(metadata: Dict[str, Any]) -> Dict[str, Any]:
         elif isinstance(value, (str, int, float, bool)):
             sanitized[key] = value
     return sanitized
+
+
+def _truncate_summary(text: str, max_length: int = 160) -> str:
+    text = text.strip()
+    if len(text) <= max_length:
+        return text
+    return f"{text[:max_length].rstrip()}…"
 
 
 def _build_llm_request(

--- a/src/apollo/client/persona_client.py
+++ b/src/apollo/client/persona_client.py
@@ -30,6 +30,7 @@ class PersonaClient:
         process: List[str],
         goal: List[str],
         emotion: List[str],
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> ServiceResponse:
         """Create a persona diary entry via Sophia."""
         payload: Dict[str, Any] = {
@@ -41,7 +42,7 @@ class PersonaClient:
             "related_process_ids": list(process),
             "related_goal_ids": list(goal),
             "emotion_tags": list(emotion),
-            "metadata": {},
+            "metadata": metadata or {},
         }
         return self._request(
             "POST", self._entries_url, "creating persona entry", json=payload


### PR DESCRIPTION
## Summary
- load Hermes provider/model overrides via config so browser + CLI chat hit real `/llm` gateways
- stream chat metadata + telemetry to `/api/diagnostics/llm` and persist every completion to persona diary entries
- document how to run Hermes locally (new `docs/HERMES_SETUP.md`) and update Phase 2 specs/verification

Closes #53

## Testing
- npm run lint
- npm run test -- --run
- poetry run ruff check src tests
- poetry run pytest
