### PR TITLE
Apollo persona diary stream

### DIFF
--- a/docs/phase2/VERIFY.md
+++ b/docs/phase2/VERIFY.md
@@ -436,6 +436,10 @@ Tested and working on:
 - Timestamp and content
 - Entry type legend
 - Statistics display
+- Stream indicator flips between Live / Connecting / Offline / Error based on diagnostics feed
+- Session filter chips appear on entries with `metadata.session_id` and clicking one filters the list
+- Metadata drawer expands to show raw payload (including `hermes_response_id`)
+- New entries arriving via streaming highlight briefly without requiring a manual refresh
 
 ## P2-M4: Persona Diary API & UI (✅ Complete)
 

--- a/webapp/src/components/PersonaDiary.css
+++ b/webapp/src/components/PersonaDiary.css
@@ -14,9 +14,12 @@
   margin: 0 0 0.5rem 0;
 }
 
-.diary-subtitle {
-  color: #888;
-  margin: 0 0 0.5rem 0;
+.diary-status {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  align-items: center;
+  color: #94a3b8;
 }
 
 .diary-stats {
@@ -181,6 +184,59 @@
   background-color: rgba(74, 222, 128, 0.1);
 }
 
+.diary-session-filter {
+  display: flex;
+  gap: 0.4rem;
+  align-items: center;
+}
+
+.diary-session-filter input {
+  padding: 0.45rem 0.75rem;
+  border-radius: 4px;
+  border: 1px solid #333;
+  background-color: #1a1a1a;
+  color: #ddd;
+  font-size: 0.85rem;
+}
+
+.session-clear {
+  padding: 0.45rem 0.75rem;
+  border-radius: 4px;
+  border: 1px solid #444;
+  background-color: transparent;
+  color: #ddd;
+  cursor: pointer;
+}
+
+.stream-pill {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  font-weight: 600;
+}
+
+.stream-pill.online {
+  background-color: rgba(74, 222, 128, 0.2);
+  color: #4ade80;
+}
+
+.stream-pill.connecting {
+  background-color: rgba(250, 204, 21, 0.2);
+  color: #facc15;
+}
+
+.stream-pill.offline {
+  background-color: rgba(148, 163, 184, 0.2);
+  color: #cbd5f5;
+}
+
+.stream-pill.error {
+  background-color: rgba(239, 68, 68, 0.2);
+  color: #f87171;
+}
+
 /* Entry metadata */
 .entry-summary {
   font-style: italic;
@@ -218,13 +274,49 @@
 
 .entry-links {
   display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
+  flex-wrap: wrap;
+  gap: 0.35rem;
 }
 
 .link-info {
   color: #60a5fa;
   font-size: 0.75rem;
+}
+
+.session-chip {
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  border: 1px solid rgba(96, 165, 250, 0.5);
+  background-color: rgba(59, 130, 246, 0.1);
+  color: #93c5fd;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  cursor: pointer;
+}
+
+.response-chip {
+  font-size: 0.7rem;
+  color: #a5b4fc;
+}
+
+.entry-metadata-details {
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 6px;
+  padding: 0.35rem 0.5rem;
+  background-color: rgba(15, 23, 42, 0.5);
+}
+
+.entry-metadata-details pre {
+  margin: 0.5rem 0 0 0;
+  font-size: 0.75rem;
+  max-height: 150px;
+  overflow: auto;
+}
+
+.diary-entry.recent .entry-content {
+  border-color: rgba(59, 130, 246, 0.6);
+  box-shadow: 0 0 20px rgba(59, 130, 246, 0.2);
 }
 
 /* Empty state */

--- a/webapp/src/components/PersonaDiary.tsx
+++ b/webapp/src/components/PersonaDiary.tsx
@@ -1,62 +1,134 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useMemo, useCallback } from 'react'
 import { usePersonaEntries } from '../hooks/useHCG'
-import { useDiagnosticsStream } from '../hooks/useDiagnosticsStream'
+import {
+  useDiagnosticsStream,
+  type DiagnosticsConnectionStatus,
+} from '../hooks/useDiagnosticsStream'
 import type { PersonaEntry } from '../types/hcg'
 import './PersonaDiary.css'
 
-function PersonaDiary() {
-  const [filterType, setFilterType] = useState<string>('')
-  const [filterSentiment, setFilterSentiment] = useState<string>('')
-  const [searchTerm, setSearchTerm] = useState<string>('')
+const PREF_KEY = 'apollo-persona-preferences'
+const HIGHLIGHT_TTL = 6000
+const MAX_ENTRIES = 150
 
-  // Fetch persona entries from API
+interface DiaryPreferences {
+  filterType: string
+  filterSentiment: string
+  searchTerm: string
+  sessionFilter: string
+}
+
+const defaultPrefs: DiaryPreferences = {
+  filterType: '',
+  filterSentiment: '',
+  searchTerm: '',
+  sessionFilter: '',
+}
+
+function PersonaDiary() {
+  const [prefs, setPrefs] = useState<DiaryPreferences>(() => {
+    try {
+      const stored = localStorage.getItem(PREF_KEY)
+      if (stored) {
+        return { ...defaultPrefs, ...JSON.parse(stored) }
+      }
+    } catch {
+      // ignore
+    }
+    return defaultPrefs
+  })
+  const { filterType, filterSentiment, searchTerm, sessionFilter } = prefs
+
   const {
     data: apiEntries,
-    refetch,
     isLoading,
     error,
   } = usePersonaEntries({
     entry_type: filterType || undefined,
     sentiment: filterSentiment || undefined,
-    limit: 100,
+    limit: MAX_ENTRIES,
   })
 
-  // Local state for entries (combines API + WebSocket)
   const [entries, setEntries] = useState<PersonaEntry[]>([])
+  const [connectionStatus, setConnectionStatus] =
+    useState<DiagnosticsConnectionStatus>('connecting')
+  const [highlightMap, setHighlightMap] = useState<Record<string, number>>({})
 
-  // Update entries when API data changes
   useEffect(() => {
-    if (apiEntries && apiEntries.length > 0) {
+    if (apiEntries?.length) {
       setEntries(apiEntries)
     }
   }, [apiEntries])
 
-  const handlePersonaEntry = useCallback(
-    (entry: PersonaEntry) => {
-      setEntries(prev => {
-        const filtered = prev.filter(existing => existing.id !== entry.id)
-        return [entry, ...filtered].slice(0, 100)
-      })
-      refetch()
-    },
-    [refetch]
-  )
+  const handlePersonaEntry = useCallback((entry: PersonaEntry) => {
+    setEntries(prev => {
+      const filtered = prev.filter(existing => existing.id !== entry.id)
+      return [entry, ...filtered].slice(0, MAX_ENTRIES)
+    })
+    setHighlightMap(prev => ({ ...prev, [entry.id]: Date.now() }))
+  }, [])
 
   useDiagnosticsStream({
     onPersonaEntry: handlePersonaEntry,
+    onConnectionChange: setConnectionStatus,
   })
 
-  // Filter entries based on search term
-  const filteredEntries = entries.filter(entry => {
-    if (!searchTerm) return true
-    const searchLower = searchTerm.toLowerCase()
-    return (
-      entry.content.toLowerCase().includes(searchLower) ||
-      entry.entry_type.toLowerCase().includes(searchLower) ||
-      entry.emotion_tags.some(tag => tag.toLowerCase().includes(searchLower)) ||
-      (entry.summary && entry.summary.toLowerCase().includes(searchLower))
-    )
-  })
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const now = Date.now()
+      setHighlightMap(prev => {
+        const next = { ...prev }
+        Object.entries(next).forEach(([id, ts]) => {
+          if (now - ts > HIGHLIGHT_TTL) {
+            delete next[id]
+          }
+        })
+        return next
+      })
+    }, 2000)
+    return () => clearInterval(interval)
+  }, [])
+
+  useEffect(() => {
+    localStorage.setItem(PREF_KEY, JSON.stringify(prefs))
+  }, [prefs])
+
+  const updatePrefs = (changes: Partial<DiaryPreferences>) =>
+    setPrefs(prev => ({ ...prev, ...changes }))
+
+  const filteredEntries = useMemo(() => {
+    return entries
+      .filter(entry => {
+        if (!searchTerm) return true
+        const lower = searchTerm.toLowerCase()
+        return (
+          entry.content.toLowerCase().includes(lower) ||
+          entry.entry_type.toLowerCase().includes(lower) ||
+          entry.emotion_tags.some(tag => tag.toLowerCase().includes(lower)) ||
+          entry.related_process_ids.some(id =>
+            id.toLowerCase().includes(lower)
+          ) ||
+          entry.related_goal_ids.some(id => id.toLowerCase().includes(lower)) ||
+          (entry.summary && entry.summary.toLowerCase().includes(lower))
+        )
+      })
+      .filter(entry =>
+        sessionFilter
+          ? entry.metadata?.session_id === sessionFilter ||
+            entry.metadata?.sessionId === sessionFilter
+          : true
+      )
+      .filter(entry => (filterType ? entry.entry_type === filterType : true))
+      .filter(entry =>
+        filterSentiment
+          ? entry.sentiment
+            ? entry.sentiment === filterSentiment
+            : false
+          : true
+      )
+  }, [entries, filterType, filterSentiment, sessionFilter, searchTerm])
+
+  const latestTimestamp = filteredEntries[0]?.timestamp
 
   const getTypeIcon = (type: string) => {
     switch (type) {
@@ -103,40 +175,155 @@ function PersonaDiary() {
     }
   }
 
-  if (error) {
-    return (
-      <div className="persona-diary">
-        <div className="diary-header">
-          <h2>Persona Diary</h2>
-          <p className="diary-error">
-            Error loading diary entries: {error.message}
+  const renderEntries = () => {
+    if (!filteredEntries.length) {
+      return (
+        <div className="diary-empty">
+          <p>No diary entries found.</p>
+          <p className="diary-help">
+            Use <code>apollo-cli diary</code> or interact via the chat panel to
+            generate entries.
           </p>
         </div>
-      </div>
-    )
+      )
+    }
+
+    return filteredEntries.map(entry => {
+      const sessionId =
+        (entry.metadata?.session_id as string | undefined) ||
+        (entry.metadata?.sessionId as string | undefined)
+      const responseId = entry.metadata?.hermes_response_id as
+        | string
+        | undefined
+      const isHighlighted = Boolean(highlightMap[entry.id])
+      return (
+        <div
+          key={entry.id}
+          className={`diary-entry ${isHighlighted ? 'recent' : ''}`}
+        >
+          <div
+            className="entry-marker"
+            style={{ backgroundColor: getTypeColor(entry.entry_type) }}
+          >
+            <span className="entry-icon">{getTypeIcon(entry.entry_type)}</span>
+          </div>
+          <div className="entry-content">
+            <div className="entry-header">
+              <span
+                className="entry-type"
+                style={{ color: getTypeColor(entry.entry_type) }}
+              >
+                {entry.entry_type.charAt(0).toUpperCase() +
+                  entry.entry_type.slice(1)}
+              </span>
+              <span className="entry-timestamp">
+                {new Date(entry.timestamp).toLocaleString()}
+              </span>
+            </div>
+            {entry.summary && (
+              <div className="entry-summary">{entry.summary}</div>
+            )}
+            <div className="entry-text">{entry.content}</div>
+            <div className="entry-metadata">
+              {entry.sentiment && (
+                <span
+                  className="entry-sentiment"
+                  style={{ color: getSentimentColor(entry.sentiment) }}
+                >
+                  Sentiment: {entry.sentiment}
+                </span>
+              )}
+              {entry.confidence != null && (
+                <span className="entry-confidence">
+                  Confidence: {(entry.confidence * 100).toFixed(0)}%
+                </span>
+              )}
+              {entry.emotion_tags.length > 0 && (
+                <div className="entry-emotions">
+                  {entry.emotion_tags.map(tag => (
+                    <span key={tag} className="emotion-tag">
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+              )}
+              {(entry.related_process_ids.length > 0 ||
+                entry.related_goal_ids.length > 0) && (
+                <div className="entry-links">
+                  {entry.related_process_ids.length > 0 && (
+                    <span className="link-info">
+                      🔗 Processes: {entry.related_process_ids.join(', ')}
+                    </span>
+                  )}
+                  {entry.related_goal_ids.length > 0 && (
+                    <span className="link-info">
+                      🎯 Goals: {entry.related_goal_ids.join(', ')}
+                    </span>
+                  )}
+                </div>
+              )}
+              {(sessionId || responseId) && (
+                <div className="entry-links">
+                  {sessionId && (
+                    <button
+                      className="session-chip"
+                      onClick={() => updatePrefs({ sessionFilter: sessionId })}
+                    >
+                      Session: {sessionId.slice(0, 8)}
+                    </button>
+                  )}
+                  {responseId && (
+                    <span className="response-chip">
+                      Hermes: {responseId.slice(0, 10)}
+                    </span>
+                  )}
+                </div>
+              )}
+              {entry.metadata && Object.keys(entry.metadata).length > 0 && (
+                <details className="entry-metadata-details">
+                  <summary>Metadata</summary>
+                  <pre>{JSON.stringify(entry.metadata, null, 2)}</pre>
+                </details>
+              )}
+            </div>
+          </div>
+        </div>
+      )
+    })
   }
 
   return (
     <div className="persona-diary">
       <div className="diary-header">
         <h2>Persona Diary</h2>
-        <p className="diary-subtitle">
-          Agent's internal reasoning and decision-making process
-        </p>
+        <div className="diary-status">
+          <span className={`stream-pill ${connectionStatus}`}>
+            {connectionStatus === 'online'
+              ? 'Live stream'
+              : connectionStatus === 'connecting'
+                ? 'Connecting…'
+                : connectionStatus === 'error'
+                  ? 'Stream error'
+                  : 'Offline'}
+          </span>
+          {error && (
+            <span className="diary-error">
+              API error: {error.message}. Showing cached entries.
+            </span>
+          )}
+        </div>
 
-        {/* Filters and Search */}
         <div className="diary-controls">
           <input
             type="text"
             placeholder="Search entries..."
             value={searchTerm}
-            onChange={e => setSearchTerm(e.target.value)}
+            onChange={e => updatePrefs({ searchTerm: e.target.value })}
             className="diary-search"
           />
-
           <select
             value={filterType}
-            onChange={e => setFilterType(e.target.value)}
+            onChange={e => updatePrefs({ filterType: e.target.value })}
             className="diary-filter"
           >
             <option value="">All Types</option>
@@ -145,10 +332,9 @@ function PersonaDiary() {
             <option value="observation">Observations</option>
             <option value="reflection">Reflections</option>
           </select>
-
           <select
             value={filterSentiment}
-            onChange={e => setFilterSentiment(e.target.value)}
+            onChange={e => updatePrefs({ filterSentiment: e.target.value })}
             className="diary-filter"
           >
             <option value="">All Sentiments</option>
@@ -157,8 +343,30 @@ function PersonaDiary() {
             <option value="neutral">Neutral</option>
             <option value="mixed">Mixed</option>
           </select>
-
-          <button onClick={() => refetch()} className="diary-refresh">
+          <div className="diary-session-filter">
+            <input
+              type="text"
+              placeholder="Session ID filter"
+              value={sessionFilter}
+              onChange={e => updatePrefs({ sessionFilter: e.target.value })}
+            />
+            {sessionFilter && (
+              <button
+                className="session-clear"
+                onClick={() =>
+                  updatePrefs({
+                    sessionFilter: '',
+                  })
+                }
+              >
+                Clear
+              </button>
+            )}
+          </div>
+          <button
+            onClick={() => setEntries(apiEntries ?? [])}
+            className="diary-refresh"
+          >
             ↻ Refresh
           </button>
         </div>
@@ -168,98 +376,14 @@ function PersonaDiary() {
           {isLoading && <span className="loading">Loading...</span>}
           <span>
             Latest:{' '}
-            {filteredEntries.length > 0
-              ? new Date(filteredEntries[0].timestamp).toLocaleTimeString()
+            {latestTimestamp
+              ? new Date(latestTimestamp).toLocaleTimeString()
               : 'N/A'}
           </span>
         </div>
       </div>
 
-      <div className="diary-timeline">
-        {filteredEntries.length === 0 ? (
-          <div className="diary-empty">
-            <p>No diary entries found.</p>
-            <p className="diary-help">
-              Use the CLI command <code>apollo-cli diary</code> to create
-              entries, or entries will be created automatically from agent
-              activities.
-            </p>
-          </div>
-        ) : (
-          filteredEntries.map(entry => (
-            <div key={entry.id} className="diary-entry">
-              <div
-                className="entry-marker"
-                style={{ backgroundColor: getTypeColor(entry.entry_type) }}
-              >
-                <span className="entry-icon">
-                  {getTypeIcon(entry.entry_type)}
-                </span>
-              </div>
-              <div className="entry-content">
-                <div className="entry-header">
-                  <span
-                    className="entry-type"
-                    style={{ color: getTypeColor(entry.entry_type) }}
-                  >
-                    {entry.entry_type.charAt(0).toUpperCase() +
-                      entry.entry_type.slice(1)}
-                  </span>
-                  <span className="entry-timestamp">
-                    {new Date(entry.timestamp).toLocaleString()}
-                  </span>
-                </div>
-
-                {entry.summary && (
-                  <div className="entry-summary">{entry.summary}</div>
-                )}
-
-                <div className="entry-text">{entry.content}</div>
-
-                <div className="entry-metadata">
-                  {entry.sentiment && (
-                    <span
-                      className="entry-sentiment"
-                      style={{ color: getSentimentColor(entry.sentiment) }}
-                    >
-                      Sentiment: {entry.sentiment}
-                    </span>
-                  )}
-                  {entry.confidence !== undefined && (
-                    <span className="entry-confidence">
-                      Confidence: {(entry.confidence * 100).toFixed(0)}%
-                    </span>
-                  )}
-                  {entry.emotion_tags.length > 0 && (
-                    <div className="entry-emotions">
-                      {entry.emotion_tags.map(tag => (
-                        <span key={tag} className="emotion-tag">
-                          {tag}
-                        </span>
-                      ))}
-                    </div>
-                  )}
-                  {(entry.related_process_ids.length > 0 ||
-                    entry.related_goal_ids.length > 0) && (
-                    <div className="entry-links">
-                      {entry.related_process_ids.length > 0 && (
-                        <span className="link-info">
-                          🔗 Processes: {entry.related_process_ids.join(', ')}
-                        </span>
-                      )}
-                      {entry.related_goal_ids.length > 0 && (
-                        <span className="link-info">
-                          🎯 Goals: {entry.related_goal_ids.join(', ')}
-                        </span>
-                      )}
-                    </div>
-                  )}
-                </div>
-              </div>
-            </div>
-          ))
-        )}
-      </div>
+      <div className="diary-timeline">{renderEntries()}</div>
 
       <div className="diary-legend">
         <h3>Entry Types</h3>


### PR DESCRIPTION
## Summary
- replace the static persona diary view with a live stream panel that remembers filters, highlights new entries, and surfaces connection status
- add session filter chips, metadata drawers, and sentiment/status badges so operators can link diary entries back to chat turns and processes
- document the richer persona diary verification steps in docs/phase2/VERIFY.md

## Testing
- npm run lint
- npm run type-check
- poetry run pytest
