### PR TITLE
ci: add 50% coverage gate and skip reporting (logos#416)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,8 @@ jobs:
         export APOLLO_API_PORT=28003
         export RUN_INTEGRATION_TESTS=1
       # Run ALL tests with full stack available
-      pytest_command: 'pytest tests/ -v --cov=apollo --cov-report=term --cov-report=xml'
+      # --cov-fail-under=50: Enforce 50% minimum coverage (per logos#416 Phase 2.5)
+      pytest_command: 'pytest tests/ -v --cov=apollo --cov-report=term --cov-report=xml --cov-fail-under=50 -r sS'
       coverage_python_version: '3.11'
       upload_coverage: false  # We'll upload with flags in a separate job
       enable_node: true


### PR DESCRIPTION
## Summary

Adds coverage enforcement and skip reporting to Apollo CI as part of the Phase 2.5 Testing Sanity initiative (logos#416).

## Changes

- Add `--cov-fail-under=50` to enforce minimum 50% code coverage
- Add `-r sS` for skip reason reporting in CI output

## Context

PR #115 addressed most of apollo#111:
- ✅ Added 42 e2e tests
- ✅ Reorganized test structure (unit/integration/e2e)
- ✅ Reduced mock usage by 74% in test_persona_store.py
- ✅ Added test infrastructure scripts
- ✅ Added docs/TESTING.md

This PR completes the remaining acceptance criteria:
- ✅ Coverage gate in CI (starting at 50%, will increase to 60% as coverage improves)
- ✅ Skip reporting for transparency

Current unit test coverage: 56%

## Related Issues

- Refs apollo#111
- Refs logos#416 (Phase 2.5: Testing Sanity)