### PR TITLE
chore: use reusable publish workflow from logos

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,3 +1,7 @@
+# Publish Apollo Container
+# Uses the standardized reusable workflow from logos
+# Part of c-daly/logos#431 - Standardize CI/CD across LOGOS repos
+
 name: Publish Apollo Container
 
 on:
@@ -11,42 +15,7 @@ permissions:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
-    
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      
-      - name: Extract version from pyproject.toml
-        id: version
-        run: |
-          VERSION=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Building Apollo version: $VERSION"
-      
-      - name: Build and push container
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./Dockerfile
-          push: true
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/apollo:${{ steps.version.outputs.version }}
-            ghcr.io/${{ github.repository_owner }}/apollo:latest
-          labels: |
-            org.opencontainers.image.title=apollo
-            org.opencontainers.image.description=Apollo UI and command layer for Project LOGOS
-            org.opencontainers.image.version=${{ steps.version.outputs.version }}
-            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+    uses: c-daly/logos/.github/workflows/reusable-publish.yml@main
+    with:
+      image_name: apollo
+    secrets: inherit


### PR DESCRIPTION
## Summary

Part of c-daly/logos#431 - Standardize CI/CD across LOGOS repos

Updates apollo's `publish.yml` to use the standardized reusable workflow from the logos repository.

## Changes

- Replaced 52-line inline workflow with call to `c-daly/logos/.github/workflows/reusable-publish.yml@main`
- Maintains same triggers (release, workflow_dispatch)

## Benefits

- **Consistency**: Same publishing behavior across all LOGOS repos
- **Maintainability**: Updates to publish logic only need to happen in one place
- **Reduced duplication**: From 52 lines to 21 lines