### PR TITLE
fix: standardize Milvus port to apollo +20000 offset

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -101,7 +101,7 @@ services:
     volumes:
     - apollo_test_milvus:/var/lib/milvus
     ports:
-    - 29530:19530
+    - 39530:19530
     - 29091:9091
     healthcheck:
       test:


### PR DESCRIPTION
## Summary
Part of logos#433 - Port standardization across LOGOS repos

Updates apollo Milvus gRPC port to use correct +20000 offset.

### Changes
- Updated `docker-compose.test.yml`:
  - Milvus gRPC: 29530 → 39530

Neo4j ports (27474/27687) and Milvus metrics (29091) were already correct.

### Port Values
| Service | Port |
|---------|------|
| Neo4j HTTP | 27474 |
| Neo4j Bolt | 27687 |
| Milvus gRPC | 39530 |
| Milvus Metrics | 29091 |