### PR TITLE
[apollo] Update evidence ports (#129)

### DIFF
--- a/docs/evidence/p2-m1/hermes_health.json
+++ b/docs/evidence/p2-m1/hermes_health.json
@@ -11,7 +11,7 @@
   "milvus": {
     "connected": false,
     "host": "localhost",
-    "port": "18530",
+    "port": "17530",
     "collection": null
   },
   "queue": {


### PR DESCRIPTION
## Summary
Update Apollo evidence artifact ports to match `logos_config`.

Closes #129

## Changes
- Updated `docs/evidence/p2-m1/hermes_health.json` to use the Hermes Milvus port (17530).

## Testing
- Not run (documentation-only change)
