### PR TITLE
[apollo] Add CLAUDE.md for agent guidance (#456)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,23 @@
+# CLAUDE.md
+
+## Required Reading
+
+Before working in this repository, read:
+
+1. **[AGENTS.md](./AGENTS.md)** - Repository-specific agent instructions
+2. **[Issue Templates](https://github.com/c-daly/logos/tree/main/.github/ISSUE_TEMPLATE)** - Use appropriate template when creating issues
+
+## Issue Template Quick Reference
+
+| Template | Use For |
+|----------|---------|
+| `apollo-task.yml` | apollo-specific tasks |
+| `infrastructure-task.yml` | HCG, ontology, CI/CD |
+| `research-task.yml` | Research/investigation |
+| `documentation-task.yml` | Docs updates |
+
+## Key Standards
+
+- **Testing**: `logos/docs/TESTING_STANDARDS.md`
+- **Git workflow**: `logos/docs/GIT_PROJECT_STANDARDS.md`
+- **Port allocation**: Each repo has unique prefix (see AGENTS.md)


### PR DESCRIPTION
## Summary
Add CLAUDE.md to provide Claude Code agents with quick reference to repo-specific instructions.

Part of c-daly/logos#456

## Changes
- Added CLAUDE.md pointing to AGENTS.md and issue templates
- References key ecosystem standards

## Testing
- Documentation only, no code changes
