### PR TITLE
refactor: route logos_config imports through apollo.env wrapper

### DIFF
--- a/src/apollo/api/server.py
+++ b/src/apollo/api/server.py
@@ -993,7 +993,7 @@ def main() -> None:
     import uvicorn
     import os
 
-    from logos_config.ports import APOLLO_PORTS
+    from apollo.env import APOLLO_PORTS
 
     port = int(os.getenv("APOLLO_PORT", str(APOLLO_PORTS.api)))
     host = os.getenv("APOLLO_HOST", "0.0.0.0")

--- a/src/apollo/config/settings.py
+++ b/src/apollo/config/settings.py
@@ -7,8 +7,7 @@ from typing import Optional
 import yaml
 from pydantic import BaseModel, Field
 
-from logos_config.env import get_env_value as resolve_env_value
-from logos_config.ports import APOLLO_PORTS, get_repo_ports
+from apollo.env import get_env_value as resolve_env_value, APOLLO_PORTS, get_repo_ports
 
 SOPHIA_PORTS = get_repo_ports("sophia")
 HERMES_PORTS = get_repo_ports("hermes")

--- a/src/apollo/env.py
+++ b/src/apollo/env.py
@@ -45,6 +45,18 @@ from logos_config.env import (
 )
 from logos_config.ports import APOLLO_PORTS, get_repo_ports
 
+# Re-export for use by other apollo modules
+__all__ = [
+    "get_env_value",
+    "get_repo_root",
+    "load_stack_env",
+    "get_neo4j_config",
+    "get_milvus_config",
+    "get_sophia_config",
+    "APOLLO_PORTS",
+    "get_repo_ports",
+]
+
 
 def get_env_value(
     key: str,


### PR DESCRIPTION
## Summary
- Route all `logos_config` imports through `apollo.env` wrapper per #433 standardization
- Add `__all__` to env.py re-exporting `APOLLO_PORTS` and `get_repo_ports`
- Update `config/settings.py` and `api/server.py` to import from `apollo.env`

## Test plan
- [x] Unit tests pass (137 passed)
- [x] Mypy passes
- [x] Ruff passes
- [ ] CI passes

Closes part of c-daly/logos#433

🤖 Generated with [Claude Code](https://claude.com/claude-code)