### PR TITLE
Pin publish.yml to ci/v2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   publish:
-    uses: c-daly/logos/.github/workflows/reusable-publish.yml@ci/v1
+    uses: c-daly/logos/.github/workflows/reusable-publish.yml@ci/v2
     with:
       image_name: apollo
     secrets: inherit


### PR DESCRIPTION
## Summary
- Update reusable-publish.yml references from @ci/v1/@main to @ci/v2

## Test plan
- [ ] Verify publish workflow still triggers correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)