### PR TITLE
Fix run_apollo.sh cold-start: fail loud + build vendored SDKs

### DIFF
--- a/scripts/run_apollo.sh
+++ b/scripts/run_apollo.sh
@@ -71,7 +71,7 @@ start_sophia() {
         log_info "Starting Sophia on port ${SOPHIA_PORT}..."
 
         cd "${SOPHIA_ROOT}"
-        poetry install --sync -E otel >/dev/null 2>&1 || true
+        poetry install --sync -E otel
 
         if [ "$DETACH" = true ]; then
             SOPHIA_API_TOKEN="${SOPHIA_API_TOKEN}" nohup poetry run uvicorn sophia.api.app:app --host 0.0.0.0 --port "${SOPHIA_PORT}" >/tmp/sophia.log 2>&1 &
@@ -109,7 +109,7 @@ start_hermes() {
     export SOPHIA_PORT="${SOPHIA_PORT:-47000}"
 
         cd "${HERMES_ROOT}"
-        poetry install --sync -E otel >/dev/null 2>&1 || true
+        poetry install --sync -E otel
 
         if [ "$DETACH" = true ]; then
             HERMES_PORT="${HERMES_PORT}" HERMES_LLM_API_KEY="${HERMES_LLM_API_KEY}" SOPHIA_API_KEY="${SOPHIA_API_KEY}" SOPHIA_HOST="${SOPHIA_HOST}" SOPHIA_PORT="${SOPHIA_PORT}" nohup poetry run python -m hermes.main >/tmp/hermes.log 2>&1 &
@@ -139,7 +139,7 @@ start_api() {
         log_info "Starting apollo-api (FastAPI) on port ${APOLLO_PORT}..."
 
         # Ensure poetry env is ready
-        poetry install --sync -E otel >/dev/null 2>&1 || true
+        poetry install --sync -E otel
 
         if [ "$DETACH" = true ]; then
             nohup poetry run apollo-api >/tmp/apollo-api.log 2>&1 &
@@ -168,6 +168,17 @@ start_webapp() {
         log_info "Starting Vite dev server on port ${WEBAPP_PORT}..."
 
         cd "${PROJECT_ROOT}/webapp"
+
+        # Vendored @logos/* SDKs are file: deps whose `prepare` step runs `tsc`.
+        # Build each one first (its own `npm install` pulls typescript + emits
+        # dist/), otherwise the webapp install fails with `tsc: not found`.
+        for sdk in vendor/@logos/*/; do
+            if [[ -f "${sdk}package.json" && ! -d "${sdk}dist" ]]; then
+                log_info "Building vendored SDK: ${sdk}"
+                (cd "${sdk}" && npm install >/dev/null)
+            fi
+        done
+
         if [[ ! -d node_modules ]]; then
             log_info "Installing webapp dependencies..."
             npm install >/dev/null

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1319,12 +1319,12 @@
       }
     },
     "node_modules/@logos/hermes-sdk": {
-      "resolved": "vendor/@logos/hermes-sdk",
-      "link": true
+      "version": "0.1.0",
+      "resolved": "file:vendor/@logos/hermes-sdk"
     },
     "node_modules/@logos/sophia-sdk": {
-      "resolved": "vendor/@logos/sophia-sdk",
-      "link": true
+      "version": "0.1.0",
+      "resolved": "file:vendor/@logos/sophia-sdk"
     },
     "node_modules/@mediapipe/tasks-vision": {
       "version": "0.10.17",
@@ -7234,18 +7234,6 @@
         "use-sync-external-store": {
           "optional": true
         }
-      }
-    },
-    "vendor/@logos/hermes-sdk": {
-      "version": "0.1.0",
-      "devDependencies": {
-        "typescript": "^4.0 || ^5.0"
-      }
-    },
-    "vendor/@logos/sophia-sdk": {
-      "version": "0.1.0",
-      "devDependencies": {
-        "typescript": "^4.0 || ^5.0"
       }
     }
   }

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1319,12 +1319,12 @@
       }
     },
     "node_modules/@logos/hermes-sdk": {
-      "version": "0.1.0",
-      "resolved": "file:vendor/@logos/hermes-sdk"
+      "resolved": "vendor/@logos/hermes-sdk",
+      "link": true
     },
     "node_modules/@logos/sophia-sdk": {
-      "version": "0.1.0",
-      "resolved": "file:vendor/@logos/sophia-sdk"
+      "resolved": "vendor/@logos/sophia-sdk",
+      "link": true
     },
     "node_modules/@mediapipe/tasks-vision": {
       "version": "0.10.17",
@@ -7234,6 +7234,18 @@
         "use-sync-external-store": {
           "optional": true
         }
+      }
+    },
+    "vendor/@logos/hermes-sdk": {
+      "version": "0.1.0",
+      "devDependencies": {
+        "typescript": "^4.0 || ^5.0"
+      }
+    },
+    "vendor/@logos/sophia-sdk": {
+      "version": "0.1.0",
+      "devDependencies": {
+        "typescript": "^4.0 || ^5.0"
       }
     }
   }


### PR DESCRIPTION
## What
Two fixes to `scripts/run_apollo.sh` that surfaced on a fresh checkout:

1. **Fail loud on install.** The three `poetry install --sync -E otel` calls were suffixed `>/dev/null 2>&1 || true`, which swallowed real failures — e.g. when a repo lacked the `otel` extra, the install errored silently and the service then started against an unpopulated venv (`ModuleNotFoundError`). Dropped the masking so failures abort with their error.
2. **Build vendored SDKs before the webapp install.** `webapp/vendor/@logos/*` are `file:` deps whose `prepare` runs `tsc`; without building them first (each one's `npm install` pulls typescript + emits `dist/`), the webapp install died with `tsc: not found`. Added a loop to build any whose `dist/` is absent.

## Notes
- `webapp/package-lock.json`: the vendored SDKs are now recorded as `file:` resolutions (a byproduct of building them). This file was already modified at session start — flag if that delta isn't what you intend.
- Depends on sophia having an `otel` extra (c-daly/sophia#143) for the de-masked sophia install to succeed.

## Verification
`bash -n` clean; the webapp build + `npm install` succeed and Vite serves once the vendored SDKs are built.