### PR TITLE
fix(explorer): show reified edge-nodes on mode switch; offset 3D label

### DIFF
--- a/webapp/src/components/hcg-explorer/HCGExplorer.tsx
+++ b/webapp/src/components/hcg-explorer/HCGExplorer.tsx
@@ -361,14 +361,23 @@ function HCGExplorerInner({
           <label>Representation</label>
           <button
             className={`hcg-btn ${graphMode === 'logical' ? 'hcg-btn--active' : ''}`}
-            onClick={() => setGraphMode('logical')}
+            onClick={() => {
+              setGraphMode('logical')
+              // Switching representation clears the entity-type filter so a
+              // filter set in one view can't silently hide nodes in the other
+              // (notably reified edge-nodes, type 'edge').
+              setFilter({ entityTypes: [] })
+            }}
             title="The graph as meant to be seen: relations rendered as edges"
           >
             Data
           </button>
           <button
             className={`hcg-btn ${graphMode === 'reified' ? 'hcg-btn--active' : ''}`}
-            onClick={() => setGraphMode('reified')}
+            onClick={() => {
+              setGraphMode('reified')
+              setFilter({ entityTypes: [] })
+            }}
             title="The graph as stored: every edge is itself a node"
           >
             All nodes

--- a/webapp/src/components/hcg-explorer/renderers/ThreeRenderer.tsx
+++ b/webapp/src/components/hcg-explorer/renderers/ThreeRenderer.tsx
@@ -148,7 +148,7 @@ const EdgeLine = memo(function EdgeLine({ sourcePos, targetPos, label }: EdgeLin
       {/* Relation label (the edge_type) */}
       {label ? (
         <Text
-          position={midpoint}
+          position={[midpoint[0], midpoint[1] + 3, midpoint[2]]}
           fontSize={2.2}
           color="#cbd5e1"
           anchorX="center"


### PR DESCRIPTION
Closes #180. Two minor follow-ups from the review of #174.

- **Reified edge-nodes no longer silently hidden** — switching the Representation toggle (Data ⇄ All nodes) now clears the `entityTypes` filter, so a type filter set in one view can't carry over and hide nodes in the other (notably the promoted `type:'edge'` nodes in reified view).
- **3D edge-label occlusion** — the relation `<Text>` label is offset `+3` on Y so it clears the midpoint marker sphere instead of overlapping it.

Verified: type-check, eslint (`--max-warnings 0`), and vitest (50/50) pass.

Do not merge without review.