### PR TITLE
ci: enable foundry-alignment guard (Dockerfile vs pyproject pin)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
   standard:
     uses: c-daly/logos/.github/workflows/reusable-standard-ci.yml@ci/v2
     with:
+      check_foundry_alignment: true
       python_versions: '["3.12"]'
       python_package_manager: 'poetry'
       python_command_prefix: 'poetry run '


### PR DESCRIPTION
Enable `check_foundry_alignment` in the reusable standard CI for apollo, so the `Dockerfile` foundry base-image tag must match the `pyproject.toml` `logos-foundry` git tag.

This guard was disabled — which is why the foundry bump's Dockerfile drift went uncaught (pyproject/lock moved to v0.7.2 while the Dockerfile stayed on 0.5.0; fixed in the bump PR). With this on, that drift fails CI.

On `main` the Dockerfile and pyproject are aligned (0.5.0), so this passes; it protects future bumps.

Do not merge without review.