### PR TITLE
fix(sdk): distinguish Hermes/Sophia read-timeout from unreachable

### DIFF
--- a/src/apollo/sdk/__init__.py
+++ b/src/apollo/sdk/__init__.py
@@ -110,6 +110,21 @@ def serialize_payload(payload: Any) -> Any:
     return payload
 
 
+def _looks_like_read_timeout(exc: BaseException) -> bool:
+    """Whether *exc* (or a wrapped cause) is a read timeout.
+
+    A read timeout means the service is reachable but too slow to respond
+    (e.g. a long LLM generation) — distinct from a connection failure. The
+    generated SDKs use urllib3, which wraps the underlying cause inside
+    ``MaxRetryError.reason``; we also match by class name so this stays correct
+    regardless of the HTTP transport (urllib3 today, possibly httpx later).
+    """
+    for candidate in (exc, getattr(exc, "reason", None), exc.__cause__):
+        if candidate is not None and "ReadTimeout" in type(candidate).__name__:
+            return True
+    return False
+
+
 def execute_sophia_call(
     sdk: SophiaSDK,
     action: str,
@@ -127,6 +142,13 @@ def execute_sophia_call(
             )
         return False, None, f"Sophia API error while {action}: {details}"
     except Exception as exc:  # noqa: BLE001
+        if _looks_like_read_timeout(exc):
+            return (
+                False,
+                None,
+                f"Sophia timed out after {sdk.timeout}s while {action} "
+                f"(reachable but slow to respond): {exc}",
+            )
         return (
             False,
             None,
@@ -151,6 +173,14 @@ def execute_hermes_call(
             )
         return False, None, f"Hermes API error while {action}: {details}"
     except Exception as exc:  # noqa: BLE001
+        if _looks_like_read_timeout(exc):
+            return (
+                False,
+                None,
+                f"Hermes timed out after {sdk.timeout}s while {action} "
+                f"(reachable but slow to respond, e.g. a long LLM "
+                f"generation): {exc}",
+            )
         return (
             False,
             None,

--- a/tests/unit/test_sdk_error_classification.py
+++ b/tests/unit/test_sdk_error_classification.py
@@ -1,0 +1,69 @@
+"""Transport-error classification in execute_*_call (apollo#171).
+
+A read timeout (service reachable but slow to respond — e.g. a long LLM
+generation) must be reported distinctly from a connection failure, instead of
+both collapsing into "Cannot reach Hermes".
+"""
+
+from types import SimpleNamespace
+
+from urllib3.exceptions import MaxRetryError, ReadTimeoutError
+
+from apollo.sdk import execute_hermes_call, execute_sophia_call
+
+
+def _sdk():
+    return SimpleNamespace(base_url="http://hermes:17000", timeout=30)
+
+
+def _raises(exc):
+    def _op():
+        raise exc
+
+    return _op
+
+
+def _read_timeout():
+    return ReadTimeoutError(None, "/llm", "Read timed out.")
+
+
+def test_hermes_read_timeout_reported_as_timeout():
+    ok, data, err = execute_hermes_call(
+        _sdk(), "generating a reply", _raises(_read_timeout())
+    )
+    assert ok is False
+    assert data is None
+    assert "timed out after 30s" in err
+    assert "Cannot reach Hermes" not in err
+
+
+def test_hermes_read_timeout_wrapped_in_maxretry_reported_as_timeout():
+    # urllib3 wraps the real cause inside MaxRetryError.reason
+    wrapped = MaxRetryError(None, "/llm", reason=_read_timeout())
+    _, _, err = execute_hermes_call(_sdk(), "generating a reply", _raises(wrapped))
+    assert "timed out after 30s" in err
+    assert "Cannot reach Hermes" not in err
+
+
+def test_hermes_connection_failure_reported_as_unreachable():
+    _, _, err = execute_hermes_call(
+        _sdk(),
+        "generating a reply",
+        _raises(ConnectionError("Connection refused")),
+    )
+    assert "Cannot reach Hermes" in err
+    assert "timed out" not in err
+
+
+def test_sophia_read_timeout_reported_as_timeout():
+    _, _, err = execute_sophia_call(_sdk(), "planning", _raises(_read_timeout()))
+    assert "timed out after 30s" in err
+    assert "Cannot connect to Sophia" not in err
+
+
+def test_sophia_connection_failure_reported_as_unreachable():
+    _, _, err = execute_sophia_call(
+        _sdk(), "planning", _raises(ConnectionError("Connection refused"))
+    )
+    assert "Cannot connect to Sophia" in err
+    assert "timed out" not in err


### PR DESCRIPTION
See #171.

## Problem
`execute_hermes_call` / `execute_sophia_call` caught every non-API exception in a bare `except Exception` and reported it as **"Cannot reach Hermes"** / **"Cannot connect to Sophia"**. A read timeout on a slow call — e.g. a long LLM generation exceeding the request timeout — therefore looked to the user like the service was *down*, when it was reachable but slow.

## Fix
- Add `_looks_like_read_timeout(exc)`: walks `exc`, `exc.reason` (urllib3 wraps the real cause in `MaxRetryError.reason`), and `exc.__cause__`, matching `ReadTimeout` by **class name** so it stays correct regardless of the HTTP transport (urllib3 today).
- Branch the bare `except` in both clients: read timeouts → **"Hermes/Sophia timed out after {N}s (reachable but slow to respond)"**; genuine connection failures keep the existing **"Cannot reach/connect"** message (backward-compatible).

## Tests
`tests/unit/test_sdk_error_classification.py` — raw `ReadTimeoutError`, `MaxRetryError`-wrapped read timeout, and connection failure, for both Hermes and Sophia. ruff / black / mypy clean; 16 SDK tests pass locally.

## Scope note (not in this PR)
This fixes the **misclassification** (the primary bug). **Raising/aligning the timeout *value*** — the issue's secondary ask — is left as a separate tuning decision: I'd recommend a dedicated, longer LLM timeout rather than bumping the shared hermes timeout (which would slow failure detection for fast calls like embeddings). A **Playwright e2e** for the chat timeout path would need a slow-Hermes stub harness; the unit tests cover the classification logic directly.

Do not merge without review.