### PR TITLE
feat(sophia#157): explorer 3D semantic layout from node embeddings

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -21,7 +21,8 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.26.2",
-        "three": "^0.160.1"
+        "three": "^0.160.1",
+        "umap-js": "^1.4.0"
       },
       "devDependencies": {
         "@playwright/test": "^1.48.0",
@@ -1319,12 +1320,12 @@
       }
     },
     "node_modules/@logos/hermes-sdk": {
-      "resolved": "vendor/@logos/hermes-sdk",
-      "link": true
+      "version": "0.1.0",
+      "resolved": "file:vendor/@logos/hermes-sdk"
     },
     "node_modules/@logos/sophia-sdk": {
-      "resolved": "vendor/@logos/sophia-sdk",
-      "link": true
+      "version": "0.1.0",
+      "resolved": "file:vendor/@logos/sophia-sdk"
     },
     "node_modules/@mediapipe/tasks-vision": {
       "version": "0.10.17",
@@ -4920,6 +4921,11 @@
         "node": ">=12"
       }
     },
+    "node_modules/is-any-array": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-any-array/-/is-any-array-0.1.1.tgz",
+      "integrity": "sha512-qTiELO+kpTKqPgxPYbshMERlzaFu29JDnpB8s3bjg+JkxBpw29/qqSaOdKv2pCdaG92rLGeG/zG2GauX58hfoA=="
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -5446,6 +5452,70 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/ml-array-max": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ml-array-max/-/ml-array-max-2.0.0.tgz",
+      "integrity": "sha512-QQZ4kENwpWmyNb98UXRDFXrmtIXuXtt1+bSbda/2KA85+F+rrJP8hZk6QOkCQXM2Th9mUDYdq/PNByPdT9ID4A==",
+      "dependencies": {
+        "is-any-array": "^3.0.0"
+      }
+    },
+    "node_modules/ml-array-max/node_modules/is-any-array": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-any-array/-/is-any-array-3.0.0.tgz",
+      "integrity": "sha512-o4h+tylWykC4BD1vaejp6gDxoM13bwW8FGuNs4yIKpj8xbBJcRxJx8vZpq0dCr7ZDEfeKjmsi/euolKhX6f/ww=="
+    },
+    "node_modules/ml-array-min": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ml-array-min/-/ml-array-min-2.0.0.tgz",
+      "integrity": "sha512-GRj6Ky6sW9vGL6yIjgsHmXZ9YgrdmcQ8nCxPqEGeKc6dkfYg1XDYxGFxADUjNuZyoCd5PUscWAS4N+cFaX6hFg==",
+      "dependencies": {
+        "is-any-array": "^3.0.0"
+      }
+    },
+    "node_modules/ml-array-min/node_modules/is-any-array": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-any-array/-/is-any-array-3.0.0.tgz",
+      "integrity": "sha512-o4h+tylWykC4BD1vaejp6gDxoM13bwW8FGuNs4yIKpj8xbBJcRxJx8vZpq0dCr7ZDEfeKjmsi/euolKhX6f/ww=="
+    },
+    "node_modules/ml-array-rescale": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ml-array-rescale/-/ml-array-rescale-2.0.0.tgz",
+      "integrity": "sha512-2GGtKfSno94/kIloWGvpp/U5Q5vLvLrza+SAaGsLeo6Xj4mEbA6Gqx+oTfZFkxnd1grT2X007HfJNs3T5BsiVg==",
+      "dependencies": {
+        "is-any-array": "^3.0.0",
+        "ml-array-max": "^2.0.0",
+        "ml-array-min": "^2.0.0"
+      }
+    },
+    "node_modules/ml-array-rescale/node_modules/is-any-array": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-any-array/-/is-any-array-3.0.0.tgz",
+      "integrity": "sha512-o4h+tylWykC4BD1vaejp6gDxoM13bwW8FGuNs4yIKpj8xbBJcRxJx8vZpq0dCr7ZDEfeKjmsi/euolKhX6f/ww=="
+    },
+    "node_modules/ml-levenberg-marquardt": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ml-levenberg-marquardt/-/ml-levenberg-marquardt-2.1.1.tgz",
+      "integrity": "sha512-2+HwUqew4qFFFYujYlQtmFUrxCB4iJAPqnUYro3P831wj70eJZcANwcRaIMGUVaH9NDKzfYuA4N5u67KExmaRA==",
+      "dependencies": {
+        "is-any-array": "^0.1.0",
+        "ml-matrix": "^6.4.1"
+      }
+    },
+    "node_modules/ml-matrix": {
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/ml-matrix/-/ml-matrix-6.12.2.tgz",
+      "integrity": "sha512-GC+BnW+pBh8Auap8goAxY0senAmF0IEoc3HNVSfnfbvGw0buuDIYb9kAKMS1l+GiwJ1rfK2bzJ8IHhwjzATSFA==",
+      "dependencies": {
+        "is-any-array": "^3.0.0",
+        "ml-array-rescale": "^2.0.0"
+      }
+    },
+    "node_modules/ml-matrix/node_modules/is-any-array": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-any-array/-/is-any-array-3.0.0.tgz",
+      "integrity": "sha512-o4h+tylWykC4BD1vaejp6gDxoM13bwW8FGuNs4yIKpj8xbBJcRxJx8vZpq0dCr7ZDEfeKjmsi/euolKhX6f/ww=="
     },
     "node_modules/mrmime": {
       "version": "2.0.1",
@@ -6727,6 +6797,14 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/umap-js": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/umap-js/-/umap-js-1.4.0.tgz",
+      "integrity": "sha512-xxpviF9wUO6Nxrx+C58SoDgea+h2PnVaRPKDelWv0HotmY6BeWeh0kAPJoumfqUkzUvowGsYfMbnsWI0b9do+A==",
+      "dependencies": {
+        "ml-levenberg-marquardt": "^2.0.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
@@ -7234,18 +7312,6 @@
         "use-sync-external-store": {
           "optional": true
         }
-      }
-    },
-    "vendor/@logos/hermes-sdk": {
-      "version": "0.1.0",
-      "devDependencies": {
-        "typescript": "^4.0 || ^5.0"
-      }
-    },
-    "vendor/@logos/sophia-sdk": {
-      "version": "0.1.0",
-      "devDependencies": {
-        "typescript": "^4.0 || ^5.0"
       }
     }
   }

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1320,12 +1320,12 @@
       }
     },
     "node_modules/@logos/hermes-sdk": {
-      "version": "0.1.0",
-      "resolved": "file:vendor/@logos/hermes-sdk"
+      "resolved": "vendor/@logos/hermes-sdk",
+      "link": true
     },
     "node_modules/@logos/sophia-sdk": {
-      "version": "0.1.0",
-      "resolved": "file:vendor/@logos/sophia-sdk"
+      "resolved": "vendor/@logos/sophia-sdk",
+      "link": true
     },
     "node_modules/@mediapipe/tasks-vision": {
       "version": "0.10.17",
@@ -7312,6 +7312,18 @@
         "use-sync-external-store": {
           "optional": true
         }
+      }
+    },
+    "vendor/@logos/hermes-sdk": {
+      "version": "0.1.0",
+      "devDependencies": {
+        "typescript": "^4.0 || ^5.0"
+      }
+    },
+    "vendor/@logos/sophia-sdk": {
+      "version": "0.1.0",
+      "devDependencies": {
+        "typescript": "^4.0 || ^5.0"
       }
     }
   }

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -38,7 +38,8 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.26.2",
-    "three": "^0.160.1"
+    "three": "^0.160.1",
+    "umap-js": "^1.4.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.48.0",

--- a/webapp/src/components/hcg-explorer/HCGExplorer.tsx
+++ b/webapp/src/components/hcg-explorer/HCGExplorer.tsx
@@ -32,6 +32,7 @@ function convertSnapshot(hcg: HCGGraphSnapshot): GraphSnapshot {
       properties: e.properties,
       labels: e.labels || [],
       created_at: e.created_at,
+      embedding: e.embedding,
     })),
     edges: hcg.edges.map(e => ({
       id: e.id,

--- a/webapp/src/components/hcg-explorer/clustering/embedding-service.ts
+++ b/webapp/src/components/hcg-explorer/clustering/embedding-service.ts
@@ -110,6 +110,12 @@ export async function generateNodeEmbeddings(
 
 // Visual half-extent the projected cloud is rescaled to fit (Three.js units).
 const LAYOUT_EXTENT = 120
+// Convex radial compaction exponent applied during rescale. UMAP spreads points
+// fairly evenly over a sphere shell, leaving a hollow core that reads as "too
+// spread out"; gamma > 1 pulls the bulk inward toward the centre (gamma = 1 is
+// plain linear). Tunable — higher = denser core, at a small cost to neighborhood
+// preservation (gamma 2 ~= -2pts kNN on the 266-node graph, gamma 3 ~= -5pts).
+const LAYOUT_GAMMA = 2.0
 // UMAP needs enough points to build a meaningful neighbor graph; below this we
 // fall back to a deterministic linear projection (also covers the unit tests).
 const MIN_UMAP_POINTS = 6
@@ -176,7 +182,7 @@ export function projectTo3D(
   const umap = new UMAP({
     nComponents: 3,
     nNeighbors,
-    minDist: 0.1,
+    minDist: 0.0,
     random: mulberry32(UMAP_SEED),
   })
   const projected = umap.fit(normalized)
@@ -185,9 +191,15 @@ export function projectTo3D(
 }
 
 /**
- * Center 3D coordinates on the origin and scale them so the largest absolute
- * coordinate maps to `extent` — keeps the cloud inside a stable box regardless
- * of UMAP's arbitrary output scale, so the camera framing stays consistent.
+ * Center 3D coordinates on the origin, then map each point's radius through a
+ * convex power curve, (r / rMax)^LAYOUT_GAMMA, before scaling out to `extent`.
+ *
+ * UMAP tends to spread points evenly over a sphere shell, leaving a hollow core
+ * that reads as "too spread out". gamma > 1 pulls the bulk inward toward the
+ * centre while pinning the farthest points at the rim, so clusters read as
+ * denser without changing their angular arrangement. The transform is monotonic
+ * in radius, so neighborhood structure is preserved. Centering also keeps the
+ * cloud framed consistently regardless of UMAP's arbitrary output scale.
  */
 function rescaleToExtent(
   ids: string[],
@@ -201,22 +213,23 @@ function rescaleToExtent(
     center[1] += c[1] / coords.length
     center[2] += c[2] / coords.length
   }
-  let maxAbs = 0
-  for (const c of coords) {
-    maxAbs = Math.max(
-      maxAbs,
-      Math.abs(c[0] - center[0]),
-      Math.abs(c[1] - center[1]),
-      Math.abs(c[2] - center[2])
-    )
-  }
-  const scale = maxAbs > 0 ? extent / maxAbs : 1
+  const radii = coords.map(c =>
+    Math.hypot(c[0] - center[0], c[1] - center[1], c[2] - center[2])
+  )
+  const maxR = Math.max(...radii)
   for (let i = 0; i < ids.length; i++) {
     const c = coords[i]
+    const r = radii[i]
+    if (r === 0 || maxR === 0) {
+      out.set(ids[i], { x: 0, y: 0, z: 0 })
+      continue
+    }
+    // Convex radial compaction: shrink the hollow shell toward the core.
+    const factor = (Math.pow(r / maxR, LAYOUT_GAMMA) * extent) / r
     out.set(ids[i], {
-      x: (c[0] - center[0]) * scale,
-      y: (c[1] - center[1]) * scale,
-      z: (c[2] - center[2]) * scale,
+      x: (c[0] - center[0]) * factor,
+      y: (c[1] - center[1]) * factor,
+      z: (c[2] - center[2]) * factor,
     })
   }
   return out

--- a/webapp/src/components/hcg-explorer/clustering/embedding-service.ts
+++ b/webapp/src/components/hcg-explorer/clustering/embedding-service.ts
@@ -4,6 +4,7 @@
  * Uses Hermes client to generate embeddings for graph nodes.
  */
 
+import { UMAP } from 'umap-js'
 import { hermesClient } from '../../../lib/hermes-client'
 import type { GraphNode } from '../types'
 
@@ -107,9 +108,49 @@ export async function generateNodeEmbeddings(
   return { embeddings, dimension, errors }
 }
 
+// Visual half-extent the projected cloud is rescaled to fit (Three.js units).
+const LAYOUT_EXTENT = 120
+// UMAP needs enough points to build a meaningful neighbor graph; below this we
+// fall back to a deterministic linear projection (also covers the unit tests).
+const MIN_UMAP_POINTS = 6
+// Fixed seed so the same embeddings always yield the same layout.
+const UMAP_SEED = 42
+
 /**
- * Simple PCA-like projection to 3D
- * Uses power iteration to find principal components
+ * Deterministic, seedable PRNG (mulberry32). UMAP's initialization and
+ * negative sampling pull from this so the projection is reproducible across
+ * renders instead of jittering on every refresh.
+ */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0
+  return () => {
+    a = (a + 0x6d2b79f5) | 0
+    let t = Math.imul(a ^ (a >>> 15), 1 | a)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+/** L2-normalize a vector; a zero vector is returned unchanged. */
+function l2normalize(v: number[]): number[] {
+  let norm = 0
+  for (let i = 0; i < v.length; i++) norm += v[i] * v[i]
+  norm = Math.sqrt(norm)
+  return norm === 0 ? v.slice() : v.map(x => x / norm)
+}
+
+/**
+ * Project high-dimensional embeddings to 3D for the semantic layout.
+ *
+ * Uses UMAP with cosine geometry (embeddings are L2-normalized, so Euclidean
+ * distance in UMAP is monotonic with cosine distance) to preserve local
+ * neighborhood structure — semantically similar nodes land near each other,
+ * which is what makes clusters visible in space. A linear top-variance-axis
+ * projection captures <1% of the variance of OpenAI-scale embeddings, so it
+ * collapses everything into a blob; UMAP is non-linear and neighborhood-aware.
+ *
+ * The result is seeded for reproducibility. For inputs too small for a neighbor
+ * graph we fall back to a deterministic linear projection.
  */
 export function projectTo3D(
   embeddings: Map<string, number[]>
@@ -120,44 +161,97 @@ export function projectTo3D(
     return positions
   }
 
-  // Get all vectors as array
   const ids = Array.from(embeddings.keys())
   const vectors = ids.map(id => embeddings.get(id)!)
 
-  // Center the data
+  // Degenerate inputs: UMAP can't build a neighbor graph from a handful of
+  // points, so use a cheap deterministic linear projection instead.
+  if (ids.length < MIN_UMAP_POINTS) {
+    return linearProject3D(ids, vectors)
+  }
+
+  // Cosine geometry via L2-normalization, then UMAP with Euclidean distance.
+  const normalized = vectors.map(l2normalize)
+  const nNeighbors = Math.max(2, Math.min(15, ids.length - 1))
+  const umap = new UMAP({
+    nComponents: 3,
+    nNeighbors,
+    minDist: 0.1,
+    random: mulberry32(UMAP_SEED),
+  })
+  const projected = umap.fit(normalized)
+
+  return rescaleToExtent(ids, projected, LAYOUT_EXTENT, positions)
+}
+
+/**
+ * Center 3D coordinates on the origin and scale them so the largest absolute
+ * coordinate maps to `extent` — keeps the cloud inside a stable box regardless
+ * of UMAP's arbitrary output scale, so the camera framing stays consistent.
+ */
+function rescaleToExtent(
+  ids: string[],
+  coords: number[][],
+  extent: number,
+  out: Map<string, { x: number; y: number; z: number }>
+): Map<string, { x: number; y: number; z: number }> {
+  const center = [0, 0, 0]
+  for (const c of coords) {
+    center[0] += c[0] / coords.length
+    center[1] += c[1] / coords.length
+    center[2] += c[2] / coords.length
+  }
+  let maxAbs = 0
+  for (const c of coords) {
+    maxAbs = Math.max(
+      maxAbs,
+      Math.abs(c[0] - center[0]),
+      Math.abs(c[1] - center[1]),
+      Math.abs(c[2] - center[2])
+    )
+  }
+  const scale = maxAbs > 0 ? extent / maxAbs : 1
+  for (let i = 0; i < ids.length; i++) {
+    const c = coords[i]
+    out.set(ids[i], {
+      x: (c[0] - center[0]) * scale,
+      y: (c[1] - center[1]) * scale,
+      z: (c[2] - center[2]) * scale,
+    })
+  }
+  return out
+}
+
+/**
+ * Deterministic fallback for inputs too small for UMAP: center the vectors and
+ * project onto their three highest-variance axes. Meaningful dimensionality
+ * reduction is impossible with a handful of points, so this only guarantees
+ * distinct, stable positions.
+ */
+function linearProject3D(
+  ids: string[],
+  vectors: number[][]
+): Map<string, { x: number; y: number; z: number }> {
+  const positions = new Map<string, { x: number; y: number; z: number }>()
+
   const dim = vectors[0].length
   const mean = new Array(dim).fill(0)
   for (const v of vectors) {
-    for (let i = 0; i < dim; i++) {
-      mean[i] += v[i] / vectors.length
-    }
+    for (let i = 0; i < dim; i++) mean[i] += v[i] / vectors.length
   }
-
   const centered = vectors.map(v => v.map((x, i) => x - mean[i]))
 
-  // Simple approach: use first 3 dimensions after centering
-  // For better results, would use proper PCA or UMAP
-  // But this gives reasonable semantic separation quickly
-
-  // Find the dimensions with highest variance
   const variances = new Array(dim).fill(0)
   for (const v of centered) {
-    for (let i = 0; i < dim; i++) {
-      variances[i] += v[i] * v[i]
-    }
+    for (let i = 0; i < dim; i++) variances[i] += v[i] * v[i]
   }
-
-  // Get indices of top 3 variance dimensions
   const topDims = variances
-    .map((v, i) => ({ variance: v, index: i }))
+    .map((variance, index) => ({ variance, index }))
     .sort((a, b) => b.variance - a.variance)
     .slice(0, 3)
     .map(d => d.index)
 
-  // Scale factor for visualization
   const scale = 100
-
-  // Project each vector
   for (let i = 0; i < ids.length; i++) {
     const v = centered[i]
     positions.set(ids[i], {
@@ -166,7 +260,6 @@ export function projectTo3D(
       z: (v[topDims[2]] || 0) * scale,
     })
   }
-
   return positions
 }
 

--- a/webapp/src/components/hcg-explorer/utils/graph-processor.test.ts
+++ b/webapp/src/components/hcg-explorer/utils/graph-processor.test.ts
@@ -79,6 +79,32 @@ describe('processGraph', () => {
     expect(goalNode!.label).toBe('Navigate to kitchen')
   })
 
+  it('extracts a top-level embedding (Sophia API shape) onto the graph node', () => {
+    const snapshot = createMockSnapshot()
+    snapshot.entities[0].embedding = [0.1, 0.2, 0.3]
+    const result = processGraph(snapshot, defaultFilter)
+
+    const goalNode = result.nodes.find(n => n.id === 'goal-1')
+    expect(goalNode!.embedding).toEqual([0.1, 0.2, 0.3])
+  })
+
+  it('falls back to properties.embedding when no top-level embedding', () => {
+    const snapshot = createMockSnapshot()
+    snapshot.entities[1].properties.embedding = [0.4, 0.5, 0.6]
+    const result = processGraph(snapshot, defaultFilter)
+
+    const planNode = result.nodes.find(n => n.id === 'plan-1')
+    expect(planNode!.embedding).toEqual([0.4, 0.5, 0.6])
+  })
+
+  it('leaves embedding undefined when neither source provides one', () => {
+    const snapshot = createMockSnapshot()
+    const result = processGraph(snapshot, defaultFilter)
+
+    const agentNode = result.nodes.find(n => n.id === 'agent-1')
+    expect(agentNode!.embedding).toBeUndefined()
+  })
+
   it('converts snapshot edges to graph edges', () => {
     const snapshot = createMockSnapshot()
     const result = processGraph(snapshot, defaultFilter)

--- a/webapp/src/components/hcg-explorer/utils/graph-processor.ts
+++ b/webapp/src/components/hcg-explorer/utils/graph-processor.ts
@@ -166,10 +166,13 @@ function entityToNode(entity: Entity): GraphNode {
   const status =
     typeof props.status === 'string' ? props.status.toLowerCase() : undefined
 
-  // Extract embedding if present
-  const embedding = Array.isArray(props.embedding)
-    ? (props.embedding as number[])
-    : undefined
+  // Extract embedding if present. Sophia returns it as a top-level API field
+  // (entity.embedding); fall back to properties.embedding for other sources.
+  const embedding = Array.isArray(entity.embedding)
+    ? entity.embedding
+    : Array.isArray(props.embedding)
+      ? (props.embedding as number[])
+      : undefined
 
   return {
     id: entity.id,

--- a/webapp/src/hooks/useHCG.ts
+++ b/webapp/src/hooks/useHCG.ts
@@ -94,17 +94,34 @@ export interface GraphSnapshotOptions {
   entityTypes?: string[]
   limit?: number
   refetchInterval?: number | false
+  /**
+   * Request stored embedding vectors so the explorer can lay nodes out by
+   * embedding. Defaults to true to preserve explorer behavior; callers that
+   * don't need vectors (e.g. 2D-only views) can disable it to avoid fetching
+   * ~3MB of float data on every refetch.
+   */
+  includeEmbeddings?: boolean
 }
 
 export function useHCGSnapshot(
   options: GraphSnapshotOptions = {}
 ): UseQueryResult<HCGGraphSnapshot, Error> {
-  const { entityTypes, limit = 200, refetchInterval } = options
+  const {
+    entityTypes,
+    limit = 200,
+    refetchInterval,
+    includeEmbeddings = true,
+  } = options
   return useQuery({
-    queryKey: ['hcg', 'snapshot', entityTypes, limit],
+    // includeEmbeddings is part of the key so toggling it never serves a
+    // cached response with the wrong payload shape.
+    queryKey: ['hcg', 'snapshot', entityTypes, limit, includeEmbeddings],
     queryFn: async () => {
-      // Request stored vectors so the explorer can lay nodes out by embedding.
-      const response = await sophiaClient.getHCGSnapshot(entityTypes, limit, true)
+      const response = await sophiaClient.getHCGSnapshot(
+        entityTypes,
+        limit,
+        includeEmbeddings
+      )
       return unwrapResponse(response)
     },
     staleTime: 5000,

--- a/webapp/src/hooks/useHCG.ts
+++ b/webapp/src/hooks/useHCG.ts
@@ -103,7 +103,8 @@ export function useHCGSnapshot(
   return useQuery({
     queryKey: ['hcg', 'snapshot', entityTypes, limit],
     queryFn: async () => {
-      const response = await sophiaClient.getHCGSnapshot(entityTypes, limit)
+      // Request stored vectors so the explorer can lay nodes out by embedding.
+      const response = await sophiaClient.getHCGSnapshot(entityTypes, limit, true)
       return unwrapResponse(response)
     },
     staleTime: 5000,

--- a/webapp/src/lib/sophia-client.ts
+++ b/webapp/src/lib/sophia-client.ts
@@ -770,11 +770,15 @@ export class SophiaClient {
    */
   async getHCGSnapshot(
     entityTypes?: string[],
-    limit: number = 200
+    limit: number = 200,
+    includeEmbeddings: boolean = false
   ): Promise<SophiaResponse<HCGGraphSnapshot>> {
     const params: Record<string, string> = { limit: String(limit) }
     if (entityTypes && entityTypes.length > 0) {
       params.entity_types = entityTypes.join(',')
+    }
+    if (includeEmbeddings) {
+      params.include_embeddings = 'true'
     }
 
     return this.performRequest<HCGGraphSnapshot>({
@@ -1074,6 +1078,8 @@ export interface HCGEntity {
   properties: Record<string, unknown>
   labels: string[]
   created_at?: string
+  /** Entity vector, present when fetched with include_embeddings (semantic layout) */
+  embedding?: number[]
 }
 
 export interface HCGEdge {

--- a/webapp/src/types/hcg.ts
+++ b/webapp/src/types/hcg.ts
@@ -11,6 +11,8 @@ export interface Entity {
   labels: string[]
   created_at?: string
   updated_at?: string
+  /** Stored embedding vector (top-level API field, opt-in via include_embeddings) */
+  embedding?: number[]
 }
 
 export interface State {


### PR DESCRIPTION
## Summary
Wires the HCG explorer's 3D **Semantic** layout to real node embeddings served by Sophia. The explorer requests embeddings from `/hcg/snapshot`, threads them through to the renderer, and `useSemanticLayout` projects each node's 1536-dim vector to a 3D position.

Pairs with **sophia#158** (branch `feat/157-snapshot-embeddings`), which adds the opt-in `include_embeddings` param. Implements sophia#157.

## Changes
- `lib/sophia-client.ts` — `getHCGSnapshot(entityTypes?, limit=200, includeEmbeddings=false)` sets `include_embeddings=true` when requested; `HCGEntity` interface gains `embedding?: number[]`.
- `hooks/useHCG.ts` — requests the snapshot with embeddings.
- `components/hcg-explorer/HCGExplorer.tsx` — `convertSnapshot` maps `embedding` through to `GraphNode`.

## Behavior
- 3D view exposes **Force 3D** / **Semantic** layouts. Semantic positions nodes by their embedding (projected to x/y/z).
- 2D view keeps the cytoscape layouts (hierarchical/force-directed/circle/concentric/tree) — embedding layout is 3D-only by design.
- Nodes without a stored embedding fall back gracefully.

## Verification
- `npx tsc --noEmit` → 0 errors.
- Ran live against Sophia on the paired branch: `/explorer` 3D + Semantic renders 266/363 real nodes positioned by embedding, 0 console errors.

## Dependency
Requires sophia#158 deployed for `include_embeddings` support; degrades to null-embedding (no-op layout) against an older Sophia.