### PR TITLE
feat(sophia#157): explorer semantic embedding layout + zoom/limit UX

### DIFF
--- a/webapp/src/components/hcg-explorer/HCGExplorer.tsx
+++ b/webapp/src/components/hcg-explorer/HCGExplorer.tsx
@@ -151,6 +151,10 @@ function HCGExplorerInner({
     entityTypes: filterConfig.entityTypes.length
       ? filterConfig.entityTypes
       : undefined,
+    // The explorer loads the whole graph for its semantic layout; request the
+    // high limit explicitly so the shared hook's default stays small for other
+    // callers (e.g. GraphViewer) (greptile #186).
+    limit: 10000,
     refetchInterval: refreshInterval > 0 ? refreshInterval : false,
   })
 

--- a/webapp/src/components/hcg-explorer/renderers/ThreeRenderer.tsx
+++ b/webapp/src/components/hcg-explorer/renderers/ThreeRenderer.tsx
@@ -403,7 +403,7 @@ function CameraControls({ focusPosition }: { focusPosition: [number, number, num
       zoomSpeed={1.2}
       panSpeed={0.8}
       minDistance={20}
-      maxDistance={800}
+      maxDistance={6000}
     />
   )
 }
@@ -418,7 +418,7 @@ export function ThreeRenderer({
 }: RendererProps) {
   return (
     <Canvas
-      camera={{ position: [0, 0, 300], fov: 60 }}
+      camera={{ position: [0, 0, 300], fov: 60, far: 20000 }}
       style={{ width: '100%', height: '100%' }}
     >
       {/* Lighting */}

--- a/webapp/src/components/hcg-explorer/renderers/ThreeRenderer.tsx
+++ b/webapp/src/components/hcg-explorer/renderers/ThreeRenderer.tsx
@@ -418,7 +418,7 @@ export function ThreeRenderer({
 }: RendererProps) {
   return (
     <Canvas
-      camera={{ position: [0, 0, 300], fov: 60, far: 20000 }}
+      camera={{ position: [0, 0, 300], fov: 60, near: 1, far: 20000 }}
       style={{ width: '100%', height: '100%' }}
     >
       {/* Lighting */}

--- a/webapp/src/hooks/useHCG.ts
+++ b/webapp/src/hooks/useHCG.ts
@@ -108,7 +108,7 @@ export function useHCGSnapshot(
 ): UseQueryResult<HCGGraphSnapshot, Error> {
   const {
     entityTypes,
-    limit = 10000,
+    limit = 200,
     refetchInterval,
     includeEmbeddings = true,
   } = options

--- a/webapp/src/hooks/useHCG.ts
+++ b/webapp/src/hooks/useHCG.ts
@@ -108,7 +108,7 @@ export function useHCGSnapshot(
 ): UseQueryResult<HCGGraphSnapshot, Error> {
   const {
     entityTypes,
-    limit = 200,
+    limit = 10000,
     refetchInterval,
     includeEmbeddings = true,
   } = options


### PR DESCRIPTION
Semantic (embedding-positioned) layout for the HCG explorer, plus the UX to view a full graph.

- Request + route node embeddings through to `GraphNode`; `includeEmbeddings` configurable.
- Project the layout with **UMAP (cosine)** instead of raw-axis selection.
- **Radial gamma compaction** (minDist=0, gamma=2) so clusters read without sprawl.
- Raise the snapshot **entity limit 200 -> 10000** (pairs with backend cap raise to `le=100000`).
- Extend camera `maxDistance` 800 -> 6000 + far plane so the larger layout can be framed when zoomed out.

Relates to sophia#157.