### PR TITLE
fix(hcg-explorer): color NDT realm-typed nodes (entity/concept/process)

### DIFF
--- a/webapp/src/components/hcg-explorer/HCGExplorer.tsx
+++ b/webapp/src/components/hcg-explorer/HCGExplorer.tsx
@@ -66,8 +66,9 @@ const LAYOUT_NAMES: Record<LayoutType, string> = {
   semantic: 'Semantic',
 }
 
-/** Well-known entity types shown first in filter bar */
-const KNOWN_ENTITY_TYPES = ['goal', 'plan', 'step', 'action', 'state', 'process', 'agent', 'object', 'location', 'workspace', 'zone', 'simulation']
+/** Well-known entity types shown first in filter bar (incl. the NDT realms
+ * entity/concept/process that sophia's realm-triage stamps on ingested nodes) */
+const KNOWN_ENTITY_TYPES = ['goal', 'plan', 'step', 'action', 'state', 'process', 'entity', 'concept', 'agent', 'object', 'location', 'workspace', 'zone', 'simulation']
 
 export interface HCGExplorerProps {
   /** Initial view mode */

--- a/webapp/src/components/hcg-explorer/renderers/CytoscapeRenderer.tsx
+++ b/webapp/src/components/hcg-explorer/renderers/CytoscapeRenderer.tsx
@@ -97,6 +97,25 @@ function getStylesheet(): cytoscape.StylesheetJson {
         'text-outline-color': NODE_COLORS.process,
       },
     },
+    // NDT realm types emitted by sophia's realm-triage on ingested nodes
+    {
+      selector: 'node[type="entity"]',
+      style: {
+        'background-color': NODE_COLORS.entity,
+        shape: 'ellipse',
+        color: '#ffffff',
+        'text-outline-color': NODE_COLORS.entity,
+      },
+    },
+    {
+      selector: 'node[type="concept"]',
+      style: {
+        'background-color': NODE_COLORS.concept,
+        shape: 'round-rectangle',
+        color: '#ffffff',
+        'text-outline-color': NODE_COLORS.concept,
+      },
+    },
     // Status-based styles
     {
       selector: 'node[status="completed"]',

--- a/webapp/src/components/hcg-explorer/types.ts
+++ b/webapp/src/components/hcg-explorer/types.ts
@@ -174,6 +174,13 @@ export const NODE_COLORS: Record<string, string> = {
   step: '#a78bfa',
   state: '#f59e0b',
   process: '#ef4444',
+  // NDT realm types — sophia's realm-triage tags HCG nodes ingested via the
+  // NLP/media pipeline with one of the three realms {entity, concept, process}
+  // as node.type. `process` doubles as a realm and a fine-grained type and
+  // already has a color above; `entity` and `concept` are added here so realm-
+  // typed nodes color instead of falling back to gray.
+  entity: '#2563eb',
+  concept: '#9333ea',
   agent: '#38bdf8',
   action: '#f97316',
   object: '#fb923c',


### PR DESCRIPTION
## Problem (ticket #32)

sophia's NDT realm-triage now stamps HCG nodes ingested via the NLP/media pipeline with one of the three realms {entity, concept, process} as their `type`. apollo's HCG Explorer colors nodes by FINE-GRAINED type via `NODE_COLORS`, which had keys like goal/plan/step/state/process/agent/object/location/etc. but NO keys for the realms `entity` or `concept`. Realm-typed nodes therefore fell back to gray (`NODE_COLORS.default`) across the 3D (Three) renderer, the Cytoscape stylesheet, the legend swatches, and the type-filter buttons. `process` already had a key, so a live graph was a confusing MIX: internal-API nodes keep fine-grained types and still colored, while ingested realm nodes went gray.

## Fix (additive, minimal -- no viz redesign)

- `webapp/src/components/hcg-explorer/types.ts`: add realm color keys to `NODE_COLORS` -- `entity` = `#2563eb` (blue), `concept` = `#9333ea` (purple); `process` keeps its existing `#ef4444`.
- `webapp/src/components/hcg-explorer/renderers/CytoscapeRenderer.tsx`: add matching `node[type="entity"]` (ellipse) and `node[type="concept"]` (round-rectangle) selector rules, mirroring the existing `node[type="process"]` rule.
- `webapp/src/components/hcg-explorer/HCGExplorer.tsx`: add `entity` and `concept` to `KNOWN_ENTITY_TYPES` (next to `process`) so legend swatches and type-filter buttons render them with a color and an ordered position instead of unlabeled gray.

No fine-grained color keys were removed -- nodes written by sophia's internal APIs keep their existing colors. The `ThreeRenderer` and `utils/graph-processor.ts` lookups use `NODE_COLORS[type] || NODE_COLORS.default`, so they pick up the new keys automatically (no change needed there).

## Verification (webapp)

- `npm run type-check` (tsc --noEmit): PASS (exit 0)
- `npm run lint` (eslint, --max-warnings 0): PASS (exit 0)
- `npm run build` (tsc && vite build): PASS (built in ~10s)

No dev server / e2e run.

Closes #32
