### PR TITLE
feat(hcg-explorer): add flat IS_A-driven Types filter

### DIFF
--- a/webapp/src/components/hcg-explorer/HCGExplorer.css
+++ b/webapp/src/components/hcg-explorer/HCGExplorer.css
@@ -302,6 +302,64 @@
   border-radius: 3px;
 }
 
+/* Types panel - flat, IS_A-driven type filter */
+.hcg-type-search {
+  width: 100%;
+  margin-bottom: 10px;
+  box-sizing: border-box;
+}
+
+.hcg-types {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-height: 260px;
+  overflow-y: auto;
+}
+
+.hcg-type-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 8px;
+  font-size: 13px;
+  text-align: left;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--hcg-text-primary);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.hcg-type-row:hover {
+  background: var(--hcg-bg-tertiary);
+}
+
+.hcg-type-row--active {
+  background: var(--hcg-accent);
+  border-color: var(--hcg-accent);
+}
+
+.hcg-type-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hcg-type-count {
+  flex-shrink: 0;
+  font-variant-numeric: tabular-nums;
+  font-size: 12px;
+  color: var(--hcg-text-secondary);
+}
+
+.hcg-type-row--active .hcg-type-count {
+  color: inherit;
+}
+
 /* Timeline */
 .hcg-timeline {
   display: flex;

--- a/webapp/src/components/hcg-explorer/HCGExplorer.tsx
+++ b/webapp/src/components/hcg-explorer/HCGExplorer.tsx
@@ -10,7 +10,12 @@ import { useHCGSnapshot, type HCGGraphSnapshot } from '../../hooks/useHCG'
 import { HCGExplorerProvider, useHCGExplorer } from './context'
 import { ThreeRenderer } from './renderers/ThreeRenderer'
 import { CytoscapeRenderer } from './renderers/CytoscapeRenderer'
-import { buildGraph, type GraphMode } from './utils/graph-processor'
+import {
+  buildGraph,
+  deriveTypeSummaries,
+  type GraphMode,
+  type TypeSummary,
+} from './utils/graph-processor'
 import { generateMockSnapshot } from './utils/mock-data'
 import type {
   LayoutType,
@@ -206,6 +211,36 @@ function HCGExplorerInner({
     }
     return ordered
   }, [currentSnapshot, graphMode])
+
+  // Flat, IS_A-driven type list for the Types panel. Counts come from IS_A
+  // edges (deriveTypeSummaries), independent of the realm-based entityTypes.
+  const typeSummaries = useMemo<TypeSummary[]>(
+    () => (currentSnapshot ? deriveTypeSummaries(currentSnapshot) : []),
+    [currentSnapshot]
+  )
+
+  // Local text filter for the Types list (filters the rows, not the graph).
+  const [typeSearch, setTypeSearch] = useState('')
+
+  const visibleTypeSummaries = useMemo<TypeSummary[]>(() => {
+    const q = typeSearch.trim().toLowerCase()
+    if (!q) return typeSummaries
+    return typeSummaries.filter(t => t.name.toLowerCase().includes(q))
+  }, [typeSummaries, typeSearch])
+
+  // Single-select an emergent type (click the active row again to clear it).
+  const handleTypeSelect = useCallback(
+    (id: string) => {
+      setFilter({
+        selectedTypeId: filterConfig.selectedTypeId === id ? null : id,
+      })
+    },
+    [filterConfig.selectedTypeId, setFilter]
+  )
+
+  const handleTypeClear = useCallback(() => {
+    setFilter({ selectedTypeId: null })
+  }, [setFilter])
 
   // Get available layouts based on view mode
   const availableLayouts = viewMode === '3d' ? LAYOUTS_3D : LAYOUTS_2D
@@ -526,6 +561,50 @@ function HCGExplorerInner({
                     <span>{type}</span>
                   </div>
                 ))}
+              </div>
+            </div>
+          </div>
+
+          {/* Types Panel - flat, IS_A-driven emergent type filter.
+              Membership comes from IS_A edges, not node.type (post-NDT
+              node.type is only the realm), so emergent type names show here. */}
+          <div className="hcg-panel">
+            <div className="hcg-panel-header">
+              <span className="hcg-panel-title">Types</span>
+              {filterConfig.selectedTypeId && (
+                <button
+                  className="hcg-btn hcg-btn--icon"
+                  onClick={handleTypeClear}
+                  title="Show all (clear type filter)"
+                >
+                  Clear
+                </button>
+              )}
+            </div>
+            <div className="hcg-panel-content">
+              <input
+                type="text"
+                className="hcg-input hcg-type-search"
+                placeholder="Filter types..."
+                value={typeSearch}
+                onChange={e => setTypeSearch(e.target.value)}
+              />
+              <div className="hcg-types">
+                {visibleTypeSummaries.length === 0 ? (
+                  <div className="hcg-node-details-empty">No types</div>
+                ) : (
+                  visibleTypeSummaries.map(t => (
+                    <button
+                      key={t.id}
+                      className={`hcg-type-row ${filterConfig.selectedTypeId === t.id ? 'hcg-type-row--active' : ''}`}
+                      onClick={() => handleTypeSelect(t.id)}
+                      title={t.name}
+                    >
+                      <span className="hcg-type-name">{t.name}</span>
+                      <span className="hcg-type-count">{t.count}</span>
+                    </button>
+                  ))
+                )}
               </div>
             </div>
           </div>

--- a/webapp/src/components/hcg-explorer/HCGExplorer.tsx
+++ b/webapp/src/components/hcg-explorer/HCGExplorer.tsx
@@ -242,6 +242,21 @@ function HCGExplorerInner({
     setFilter({ selectedTypeId: null })
   }, [setFilter])
 
+  // Drop a stale type selection when the active snapshot no longer contains the
+  // selected type-definition node (e.g. navigating the timeline to a snapshot
+  // that predates the type). Otherwise computeTypeMemberIds would return only
+  // the missing id and processGraph would filter every node out, leaving an
+  // empty canvas with an active-but-invisible filter. Only clears when the type
+  // is truly absent, so valid selections survive timeline navigation.
+  useEffect(() => {
+    if (
+      filterConfig.selectedTypeId &&
+      !typeSummaries.some(t => t.id === filterConfig.selectedTypeId)
+    ) {
+      setFilter({ selectedTypeId: null })
+    }
+  }, [typeSummaries, filterConfig.selectedTypeId, setFilter])
+
   // Get available layouts based on view mode
   const availableLayouts = viewMode === '3d' ? LAYOUTS_3D : LAYOUTS_2D
 
@@ -599,6 +614,7 @@ function HCGExplorerInner({
                       className={`hcg-type-row ${filterConfig.selectedTypeId === t.id ? 'hcg-type-row--active' : ''}`}
                       onClick={() => handleTypeSelect(t.id)}
                       title={t.name}
+                      aria-pressed={filterConfig.selectedTypeId === t.id}
                     >
                       <span className="hcg-type-name">{t.name}</span>
                       <span className="hcg-type-count">{t.count}</span>

--- a/webapp/src/components/hcg-explorer/types.ts
+++ b/webapp/src/components/hcg-explorer/types.ts
@@ -83,6 +83,13 @@ export interface FilterConfig {
   propertyFilters: PropertyFilter[]
   /** Cluster filter (show only specific clusters) */
   clusters: string[]
+  /**
+   * Selected emergent-type definition node id (the IS_A target). When set, the
+   * graph is filtered to that type node plus its IS_A members. Independent of
+   * the realm-based `entityTypes` filter. Optional so existing FilterConfig
+   * literals keep type-checking; treated as null when absent.
+   */
+  selectedTypeId?: string | null
 }
 
 /** Property filter definition */
@@ -215,6 +222,7 @@ export const DEFAULT_FILTER_CONFIG: FilterConfig = {
   searchQuery: '',
   propertyFilters: [],
   clusters: [],
+  selectedTypeId: null,
 }
 
 /** Default embedding configuration */

--- a/webapp/src/components/hcg-explorer/utils/graph-processor.ts
+++ b/webapp/src/components/hcg-explorer/utils/graph-processor.ts
@@ -114,7 +114,71 @@ export function buildGraph(
 ): ProcessedGraph {
   const transformed =
     mode === 'reified' ? toReifiedSnapshot(snapshot) : toLogicalSnapshot(snapshot)
-  return processGraph(transformed, filterConfig)
+  // Type membership is read from the ORIGINAL snapshot IS_A edges (not the
+  // transformed one) so the selected-type filter is correct in both modes:
+  // reification rewrites edges into FROM/TO and would otherwise lose IS_A.
+  const typeMemberIds = computeTypeMemberIds(
+    snapshot,
+    filterConfig.selectedTypeId ?? null
+  )
+  return processGraph(transformed, filterConfig, typeMemberIds)
+}
+
+/** A flat (non-hierarchical) summary of one emergent/ontology type. */
+export interface TypeSummary {
+  /** type-definition node id (the IS_A target) */
+  id: string
+  /** human-readable type name, e.g. "chemical element" */
+  name: string
+  /** number of content nodes that IS_A this type */
+  count: number
+}
+
+/**
+ * Flat list of type-definition entities with their IS_A member counts.
+ *
+ * Post-NDT a node "type" property holds only its realm (entity, concept,
+ * process) plus the literal "type_definition", so emergent type NAMES never
+ * appear there. The real type of a node is its IS_A edge to a type-definition
+ * node, so membership is read from IS_A edges: the count for a type T is the
+ * number of edges with edge_type==="IS_A" and target_id===T.id. Source types
+ * are every entity with type==="type_definition" (this intentionally includes
+ * realm roots and reserved nodes). Sorted by count descending, then name.
+ */
+export function deriveTypeSummaries(snapshot: GraphSnapshot): TypeSummary[] {
+  const counts = new Map<string, number>()
+  for (const e of snapshot.edges) {
+    if (e.edge_type === 'IS_A') {
+      counts.set(e.target_id, (counts.get(e.target_id) ?? 0) + 1)
+    }
+  }
+  return snapshot.entities
+    .filter(e => e.type === 'type_definition')
+    .map(e => ({
+      id: e.id,
+      name: e.name || (e.properties?.name as string) || e.id,
+      count: counts.get(e.id) ?? 0,
+    }))
+    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name))
+}
+
+/**
+ * Build the set of node ids that belong to a selected emergent type: the
+ * type-definition node itself plus the source_id of every IS_A edge that
+ * targets it. Returns null when nothing is selected (no filtering).
+ */
+export function computeTypeMemberIds(
+  snapshot: GraphSnapshot,
+  selectedTypeId: string | null
+): Set<string> | null {
+  if (!selectedTypeId) return null
+  const ids = new Set<string>([selectedTypeId])
+  for (const e of snapshot.edges) {
+    if (e.edge_type === 'IS_A' && e.target_id === selectedTypeId) {
+      ids.add(e.source_id)
+    }
+  }
+  return ids
 }
 
 /**
@@ -122,7 +186,8 @@ export function buildGraph(
  */
 export function processGraph(
   snapshot: GraphSnapshot,
-  filterConfig: FilterConfig
+  filterConfig: FilterConfig,
+  typeMemberIds?: Set<string> | null
 ): ProcessedGraph {
   // Convert entities to nodes
   let nodes = snapshot.entities.map(entityToNode)
@@ -132,6 +197,13 @@ export function processGraph(
 
   // Apply filters
   nodes = applyNodeFilters(nodes, filterConfig)
+
+  // Restrict to a selected emergent type: keep only the type node and its
+  // IS_A members (see buildGraph / computeTypeMemberIds). Membership comes
+  // from IS_A edges, not node.type, since post-NDT node.type is just the realm.
+  if (typeMemberIds) {
+    nodes = nodes.filter(n => typeMemberIds.has(n.id))
+  }
 
   // Filter edges to only include those with visible nodes
   const nodeIds = new Set(nodes.map(n => n.id))

--- a/webapp/src/components/hcg-explorer/utils/graph-processor.ts
+++ b/webapp/src/components/hcg-explorer/utils/graph-processor.ts
@@ -156,7 +156,7 @@ export function deriveTypeSummaries(snapshot: GraphSnapshot): TypeSummary[] {
     .filter(e => e.type === 'type_definition')
     .map(e => ({
       id: e.id,
-      name: e.name || (e.properties?.name as string) || e.id,
+      name: String(e.name || e.properties?.name || e.id),
       count: counts.get(e.id) ?? 0,
     }))
     .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name))

--- a/webapp/src/components/hcg-explorer/utils/types-filter.test.ts
+++ b/webapp/src/components/hcg-explorer/utils/types-filter.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Tests for the flat, IS_A-driven Types filter: deriveTypeSummaries,
+ * computeTypeMemberIds, and buildGraph type-member filtering.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  deriveTypeSummaries,
+  computeTypeMemberIds,
+  buildGraph,
+} from './graph-processor'
+import type { GraphSnapshot, FilterConfig, CausalEdge } from '../types'
+
+const defaultFilter: FilterConfig = {
+  entityTypes: [],
+  edgeTypes: [],
+  status: [],
+  searchQuery: '',
+  propertyFilters: [],
+  clusters: [],
+  selectedTypeId: null,
+}
+
+function edge(
+  id: string,
+  source: string,
+  target: string,
+  edgeType: string
+): CausalEdge {
+  return {
+    id,
+    source_id: source,
+    target_id: target,
+    edge_type: edgeType,
+    properties: {},
+    weight: 1,
+    created_at: '',
+  }
+}
+
+// Snapshot where the emergent type is defined by IS_A edges, while node.type is
+// only the realm (entity/concept) - exactly the post-NDT shape.
+const typedSnapshot = (): GraphSnapshot => ({
+  entities: [
+    {
+      id: 'type_elem',
+      type: 'type_definition',
+      name: 'chemical element',
+      properties: {},
+      labels: [],
+    },
+    {
+      id: 'type_metal',
+      type: 'type_definition',
+      name: 'metal',
+      properties: {},
+      labels: [],
+    },
+    { id: 'iron', type: 'entity', name: 'Iron', properties: {}, labels: [] },
+    { id: 'gold', type: 'entity', name: 'Gold', properties: {}, labels: [] },
+    {
+      id: 'oxygen',
+      type: 'concept',
+      name: 'Oxygen',
+      properties: {},
+      labels: [],
+    },
+  ],
+  edges: [
+    edge('e1', 'iron', 'type_elem', 'IS_A'),
+    edge('e2', 'gold', 'type_elem', 'IS_A'),
+    edge('e3', 'oxygen', 'type_elem', 'IS_A'),
+    edge('e4', 'iron', 'type_metal', 'IS_A'),
+    edge('e5', 'iron', 'gold', 'RELATED'),
+  ],
+  timestamp: '',
+  metadata: {},
+})
+
+describe('deriveTypeSummaries', () => {
+  it('lists type_definition entities with IS_A member counts, sorted desc', () => {
+    const summaries = deriveTypeSummaries(typedSnapshot())
+    expect(summaries.map(t => t.name)).toEqual(['chemical element', 'metal'])
+    expect(summaries.find(t => t.id === 'type_elem')!.count).toBe(3)
+    expect(summaries.find(t => t.id === 'type_metal')!.count).toBe(1)
+  })
+
+  it('counts membership from IS_A edges, not node.type', () => {
+    // oxygen has node.type "concept" but IS_A chemical element -> must count
+    const summaries = deriveTypeSummaries(typedSnapshot())
+    expect(summaries.find(t => t.id === 'type_elem')!.count).toBe(3)
+  })
+
+  it('ignores non-IS_A edges when counting', () => {
+    const summaries = deriveTypeSummaries(typedSnapshot())
+    // the RELATED edge iron->gold must not turn gold into a type
+    expect(summaries.find(t => t.id === 'gold')).toBeUndefined()
+  })
+})
+
+describe('computeTypeMemberIds', () => {
+  it('returns null when nothing is selected', () => {
+    expect(computeTypeMemberIds(typedSnapshot(), null)).toBeNull()
+  })
+
+  it('includes the type node and every IS_A source', () => {
+    const ids = computeTypeMemberIds(typedSnapshot(), 'type_elem')!
+    expect([...ids].sort()).toEqual(['gold', 'iron', 'oxygen', 'type_elem'])
+  })
+})
+
+describe('buildGraph type filter', () => {
+  it('restricts the graph to the selected type node + its IS_A members', () => {
+    const g = buildGraph(typedSnapshot(), 'logical', {
+      ...defaultFilter,
+      selectedTypeId: 'type_elem',
+    })
+    expect(g.nodes.map(n => n.id).sort()).toEqual([
+      'gold',
+      'iron',
+      'oxygen',
+      'type_elem',
+    ])
+  })
+
+  it('shows everything when no type is selected', () => {
+    const g = buildGraph(typedSnapshot(), 'logical', defaultFilter)
+    expect(g.nodes).toHaveLength(5)
+  })
+})


### PR DESCRIPTION
## What

Adds a flat, searchable Types filter to the HCG explorer sidebar. Each row is a type name plus its member count, sorted by member count descending. Selecting a type filters the rendered graph to that type node plus its members. Single-select, with a clear/reset to show everything again. This is deliberately NOT hierarchical.

## Why the old legend could not show emergent types

The existing type list/legend derives its entries from each node type property. Post-NDT that property is only the realm (entity, concept, or process) plus the literal type_definition, so the emergent type NAMES (for example, chemical element) never appeared. A content node real type is defined by its IS_A edge to a type_definition node, not by node.type. This filter reads membership from IS_A edges instead.

## How

- deriveTypeSummaries(snapshot): the panel source. Lists every entity with type === type_definition (realm roots and reserved nodes included, as intended) and computes each count from IS_A edges: the count for a type T is the number of edges where edge_type === IS_A and target_id === T.id. Sorted by count desc, then name.
- computeTypeMemberIds(snapshot, selectedTypeId): the selected type node plus the source_id of every IS_A edge that targets it.
- buildGraph computes the member set from the ORIGINAL snapshot (so it is correct in both the logical and reified views, since reification rewrites edges) and threads it into processGraph, which filters the node set; edges prune to visible nodes automatically.

## Scope / compatibility

- selectedTypeId is a new, optional, independent FilterConfig field. The existing realm/entityTypes filter and legend are unchanged.
- processGraph gains an optional third parameter, so existing callers are unaffected.

## Tests

New unit tests (types-filter.test.ts) cover the IS_A-driven counting and filtering, including a node whose realm (node.type) differs from its IS_A type.

## Verification (cwd webapp)

- npm run type-check: pass
- npm run lint: pass (0 warnings, max-warnings 0)
- npm run build: pass
- vitest (graph-processor + types-filter): 28 passed

Note: did not run dev server or e2e, per task.