### PR TITLE
feat: HCG explorer de-hairball bundle - skeleton-first, highlight, hierarchical, edge toggle

### DIFF
--- a/webapp/src/components/hcg-explorer/HCGExplorer.css
+++ b/webapp/src/components/hcg-explorer/HCGExplorer.css
@@ -215,6 +215,26 @@
   padding: 16px;
 }
 
+/* De-hairball view controls */
+.hcg-view-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.hcg-btn-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+
+.hcg-view-label {
+  font-size: 11px;
+  color: var(--hcg-text-secondary);
+  margin-right: 4px;
+}
+
 /* Node details panel */
 .hcg-node-details {
   font-size: 13px;

--- a/webapp/src/components/hcg-explorer/HCGExplorer.css
+++ b/webapp/src/components/hcg-explorer/HCGExplorer.css
@@ -551,3 +551,39 @@
     width: 100%;
   }
 }
+
+/* Layout density controls */
+.hcg-density-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.hcg-density-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.hcg-density-row .hcg-view-label {
+  flex: 0 0 88px;
+  margin-right: 0;
+}
+
+.hcg-density-row input[type='range'] {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.hcg-density-value {
+  flex: 0 0 36px;
+  text-align: right;
+  font-size: 11px;
+  color: var(--hcg-text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+
+.hcg-btn--small {
+  padding: 2px 8px;
+  font-size: 11px;
+}

--- a/webapp/src/components/hcg-explorer/HCGExplorer.tsx
+++ b/webapp/src/components/hcg-explorer/HCGExplorer.tsx
@@ -12,6 +12,8 @@ import { ThreeRenderer } from './renderers/ThreeRenderer'
 import { CytoscapeRenderer } from './renderers/CytoscapeRenderer'
 import {
   buildGraph,
+  computeHighlightSubgraphIds,
+  computeTypeMemberIds,
   deriveTypeSummaries,
   type GraphMode,
   type TypeSummary,
@@ -57,7 +59,7 @@ function convertSnapshot(hcg: HCGGraphSnapshot): GraphSnapshot {
 }
 
 /** Available layouts for each view mode */
-const LAYOUTS_2D: LayoutType[] = ['dagre', 'fcose', 'circle', 'concentric', 'breadthfirst']
+const LAYOUTS_2D: LayoutType[] = ['dagre', 'fcose', 'circle', 'concentric', 'breadthfirst', 'hierarchical']
 const LAYOUTS_3D: LayoutType[] = ['force-3d', 'semantic']
 
 /** Layout display names */
@@ -67,6 +69,7 @@ const LAYOUT_NAMES: Record<LayoutType, string> = {
   circle: 'Circle',
   concentric: 'Concentric',
   breadthfirst: 'Tree',
+  hierarchical: 'IS_A Tree',
   'force-3d': 'Force 3D',
   semantic: 'Semantic',
 }
@@ -201,9 +204,12 @@ function HCGExplorerInner({
     // you type a search. Using DEFAULT_FILTER_CONFIG also drops the filterConfig
     // dependency, so this no longer rebuilds the whole graph on every keystroke.
     const seen = new Set(
-      buildGraph(currentSnapshot, graphMode, DEFAULT_FILTER_CONFIG).nodes.map(
-        n => n.type
-      )
+      buildGraph(currentSnapshot, graphMode, {
+        ...DEFAULT_FILTER_CONFIG,
+        // Reflect all realms even when the skeleton-first default is active, so
+        // the realm filter buttons / legend never collapse to type_definition.
+        skeletonOnly: false,
+      }).nodes.map(n => n.type)
     )
     const ordered = KNOWN_ENTITY_TYPES.filter(t => seen.has(t))
     for (const t of seen) {
@@ -265,6 +271,22 @@ function HCGExplorerInner({
     if (!selectedNodeId) return null
     return processedGraph.nodes.find(n => n.id === selectedNodeId) || null
   }, [selectedNodeId, processedGraph.nodes])
+
+  // Highlight-subgraph ids for the current focus. A selected emergent type
+  // (Types panel) takes precedence over a clicked node. Threaded to both
+  // renderers, which keep these nodes/edges bright and dim the rest, preserving
+  // context. Null when nothing is focused (no dimming). This is the default
+  // interaction; the restrict-style hard filter lives behind the selection mode.
+  const highlightedNodeIds = useMemo<Set<string> | null>(() => {
+    if (!currentSnapshot) return null
+    if (filterConfig.selectedTypeId) {
+      return computeTypeMemberIds(currentSnapshot, filterConfig.selectedTypeId)
+    }
+    if (selectedNodeId) {
+      return computeHighlightSubgraphIds(currentSnapshot, selectedNodeId)
+    }
+    return null
+  }, [currentSnapshot, filterConfig.selectedTypeId, selectedNodeId])
 
   // Handle view mode change
   const handleViewModeChange = useCallback(
@@ -491,6 +513,7 @@ function HCGExplorerInner({
               onNodeSelect={selectNode}
               onNodeHover={hoverNode}
               layout={layout}
+              highlightedNodeIds={highlightedNodeIds}
             />
           )}
 
@@ -502,12 +525,67 @@ function HCGExplorerInner({
               onNodeSelect={selectNode}
               onNodeHover={hoverNode}
               layout={layout}
+              highlightedNodeIds={highlightedNodeIds}
             />
           )}
         </div>
 
         {/* Sidebar */}
         <div className="hcg-sidebar">
+          {/* View controls (de-hairball): skeleton scope, edge kinds, selection mode. */}
+          <div className="hcg-panel">
+            <div className="hcg-panel-header">
+              <span className="hcg-panel-title">View</span>
+            </div>
+            <div className="hcg-panel-content hcg-view-controls">
+              <button
+                className={`hcg-btn ${filterConfig.skeletonOnly ? 'hcg-btn--active' : ''}`}
+                onClick={() => setFilter({ skeletonOnly: !filterConfig.skeletonOnly })}
+                title="Skeleton-first: show only the type_definition IS_A skeleton"
+              >
+                {filterConfig.skeletonOnly ? 'Skeleton only' : 'Full graph'}
+              </button>
+              <div className="hcg-btn-row">
+                <span className="hcg-view-label">Edges</span>
+                <button
+                  className={`hcg-btn ${(filterConfig.edgeKind ?? 'both') === 'both' ? 'hcg-btn--active' : ''}`}
+                  onClick={() => setFilter({ edgeKind: 'both' })}
+                >
+                  Both
+                </button>
+                <button
+                  className={`hcg-btn ${filterConfig.edgeKind === 'is_a' ? 'hcg-btn--active' : ''}`}
+                  onClick={() => setFilter({ edgeKind: 'is_a' })}
+                >
+                  IS_A
+                </button>
+                <button
+                  className={`hcg-btn ${filterConfig.edgeKind === 'semantic' ? 'hcg-btn--active' : ''}`}
+                  onClick={() => setFilter({ edgeKind: 'semantic' })}
+                >
+                  Semantic
+                </button>
+              </div>
+              <div className="hcg-btn-row">
+                <span className="hcg-view-label">Select</span>
+                <button
+                  className={`hcg-btn ${(filterConfig.selectionMode ?? 'highlight') === 'highlight' ? 'hcg-btn--active' : ''}`}
+                  onClick={() => setFilter({ selectionMode: 'highlight' })}
+                  title="Selecting dims the rest but keeps context"
+                >
+                  Highlight
+                </button>
+                <button
+                  className={`hcg-btn ${filterConfig.selectionMode === 'restrict' ? 'hcg-btn--active' : ''}`}
+                  onClick={() => setFilter({ selectionMode: 'restrict' })}
+                  title="Selecting a type restricts the graph to its members"
+                >
+                  Restrict
+                </button>
+              </div>
+            </div>
+          </div>
+
           {/* Node Details Panel */}
           {showNodeDetails && (
             <div className="hcg-panel">

--- a/webapp/src/components/hcg-explorer/HCGExplorer.tsx
+++ b/webapp/src/components/hcg-explorer/HCGExplorer.tsx
@@ -293,6 +293,11 @@ function HCGExplorerInner({
   // interaction; the restrict-style hard filter lives behind the selection mode.
   const highlightedNodeIds = useMemo<Set<string> | null>(() => {
     if (!currentSnapshot) return null
+    // Restrict mode already hard-filters the graph to the selection in
+    // buildGraph; dimming on top of that is redundant for a selected type and
+    // wrongly dims the whole graph when a single node is clicked. Dimming is the
+    // highlight-mode affordance only.
+    if (filterConfig.selectionMode === 'restrict') return null
     if (filterConfig.selectedTypeId) {
       return computeTypeMemberIds(currentSnapshot, filterConfig.selectedTypeId)
     }
@@ -300,7 +305,12 @@ function HCGExplorerInner({
       return computeHighlightSubgraphIds(currentSnapshot, selectedNodeId)
     }
     return null
-  }, [currentSnapshot, filterConfig.selectedTypeId, selectedNodeId])
+  }, [
+    currentSnapshot,
+    filterConfig.selectedTypeId,
+    filterConfig.selectionMode,
+    selectedNodeId,
+  ])
 
   // Handle view mode change
   const handleViewModeChange = useCallback(

--- a/webapp/src/components/hcg-explorer/HCGExplorer.tsx
+++ b/webapp/src/components/hcg-explorer/HCGExplorer.tsx
@@ -27,6 +27,11 @@ import type {
   GraphSnapshot,
 } from './types'
 import { NODE_COLORS, DEFAULT_FILTER_CONFIG } from './types'
+import {
+  DEFAULT_DENSITY,
+  DENSITY_RANGES,
+  type DensityParams,
+} from './utils/layout-density'
 import './HCGExplorer.css'
 
 /** Convert HCGGraphSnapshot to our internal GraphSnapshot type (keeps all entities) */
@@ -150,6 +155,10 @@ function HCGExplorerInner({
   // - 'reified': the graph as stored (every edge is a node — "all nodes")
   const [graphMode, setGraphMode] = useState<GraphMode>('logical')
 
+  // Layout density controls (force layouts + spacing for hierarchical/tree).
+  // Passed to both renderers; changing a slider re-lays-out the canvas live.
+  const [densityParams, setDensityParams] = useState<DensityParams>(DEFAULT_DENSITY)
+
   // Fetch graph data
   const {
     data: apiSnapshot,
@@ -255,8 +264,13 @@ function HCGExplorerInner({
   // empty canvas with an active-but-invisible filter. Only clears when the type
   // is truly absent, so valid selections survive timeline navigation.
   useEffect(() => {
+    // Only drop the selection when we have a populated type list that genuinely
+    // lacks the selected type. An empty list usually means the snapshot is
+    // mid-refetch (the 15s poll) or filtered down to no type-definition nodes;
+    // clearing then would nuke a still-valid selection on every refresh.
     if (
       filterConfig.selectedTypeId &&
+      typeSummaries.length > 0 &&
       !typeSummaries.some(t => t.id === filterConfig.selectedTypeId)
     ) {
       setFilter({ selectedTypeId: null })
@@ -302,6 +316,14 @@ function HCGExplorerInner({
       setLayout(e.target.value as LayoutType)
     },
     [setLayout]
+  )
+
+  // Handle a layout-density slider change (live re-layout in both renderers).
+  const handleDensityChange = useCallback(
+    (key: keyof DensityParams, value: number) => {
+      setDensityParams(prev => ({ ...prev, [key]: value }))
+    },
+    []
   )
 
   // Handle search
@@ -514,6 +536,7 @@ function HCGExplorerInner({
               onNodeHover={hoverNode}
               layout={layout}
               highlightedNodeIds={highlightedNodeIds}
+              densityParams={densityParams}
             />
           )}
 
@@ -526,6 +549,7 @@ function HCGExplorerInner({
               onNodeHover={hoverNode}
               layout={layout}
               highlightedNodeIds={highlightedNodeIds}
+              densityParams={densityParams}
             />
           )}
         </div>
@@ -583,6 +607,67 @@ function HCGExplorerInner({
                   Restrict
                 </button>
               </div>
+            </div>
+          </div>
+
+          {/* Layout density controls. Force layouts use all three; the
+              hierarchical / tree layouts honour spacing (link distance) only. */}
+          <div className="hcg-panel">
+            <div className="hcg-panel-header">
+              <span className="hcg-panel-title">Layout</span>
+              <button
+                className="hcg-btn hcg-btn--small"
+                onClick={() => setDensityParams(DEFAULT_DENSITY)}
+                title="Reset layout density to defaults"
+              >
+                Reset
+              </button>
+            </div>
+            <div className="hcg-panel-content hcg-density-controls">
+              <label className="hcg-density-row">
+                <span className="hcg-view-label">Repulsion</span>
+                <input
+                  type="range"
+                  min={DENSITY_RANGES.repulsion.min}
+                  max={DENSITY_RANGES.repulsion.max}
+                  step={DENSITY_RANGES.repulsion.step}
+                  value={densityParams.repulsion}
+                  onChange={e =>
+                    handleDensityChange('repulsion', Number(e.target.value))
+                  }
+                />
+                <span className="hcg-density-value">{densityParams.repulsion}</span>
+              </label>
+              <label className="hcg-density-row">
+                <span className="hcg-view-label">Link distance</span>
+                <input
+                  type="range"
+                  min={DENSITY_RANGES.linkDistance.min}
+                  max={DENSITY_RANGES.linkDistance.max}
+                  step={DENSITY_RANGES.linkDistance.step}
+                  value={densityParams.linkDistance}
+                  onChange={e =>
+                    handleDensityChange('linkDistance', Number(e.target.value))
+                  }
+                />
+                <span className="hcg-density-value">{densityParams.linkDistance}</span>
+              </label>
+              <label className="hcg-density-row">
+                <span className="hcg-view-label">Gravity</span>
+                <input
+                  type="range"
+                  min={DENSITY_RANGES.gravity.min}
+                  max={DENSITY_RANGES.gravity.max}
+                  step={DENSITY_RANGES.gravity.step}
+                  value={densityParams.gravity}
+                  onChange={e =>
+                    handleDensityChange('gravity', Number(e.target.value))
+                  }
+                />
+                <span className="hcg-density-value">
+                  {densityParams.gravity.toFixed(2)}
+                </span>
+              </label>
             </div>
           </div>
 

--- a/webapp/src/components/hcg-explorer/clustering/embedding-service.test.ts
+++ b/webapp/src/components/hcg-explorer/clustering/embedding-service.test.ts
@@ -5,9 +5,11 @@
 import { describe, it, expect } from 'vitest'
 import {
   projectTo3D,
+  projectNodesTo3D,
   cosineSimilarity,
   clusterByEmbedding,
 } from './embedding-service'
+import type { GraphNode } from '../types'
 
 describe('cosineSimilarity', () => {
   it('returns 1 for identical vectors', () => {
@@ -180,6 +182,62 @@ describe('clusterByEmbedding', () => {
     for (const clusterId of clusters.values()) {
       expect(Number.isInteger(clusterId)).toBe(true)
       expect(clusterId).toBeGreaterThanOrEqual(0)
+    }
+  })
+})
+
+describe(projectNodesTo3D, () => {
+  function node(id: string, embedding?: number[]): GraphNode {
+    return {
+      id,
+      label: id,
+      type: 'entity',
+      properties: {},
+      embedding,
+      raw: {},
+    } as unknown as GraphNode
+  }
+
+  it('projects embedded nodes and reports the embedded count', () => {
+    const nodes = [
+      node('a', [1, 0, 0, 0]),
+      node('b', [0, 1, 0, 0]),
+      node('c', [0, 0, 1, 0]),
+    ]
+    const { positions, embeddedCount } = projectNodesTo3D(nodes)
+    expect(embeddedCount).toBe(3)
+    expect(positions.size).toBe(3)
+    for (const id of ['a', 'b', 'c']) {
+      const p = positions.get(id)!
+      expect(p).toBeDefined()
+      expect(p.every(c => Number.isFinite(c))).toBe(true)
+    }
+    // Distinct embeddings must not collapse to a single point.
+    expect(positions.get('a')).not.toEqual(positions.get('b'))
+  })
+
+  it('places nodes without embeddings on a visible off-origin shell', () => {
+    const nodes = [
+      node('a', [1, 0, 0, 0]),
+      node('b', [0, 1, 0, 0]),
+      node('c'),
+    ]
+    const { positions, embeddedCount } = projectNodesTo3D(nodes)
+    expect(embeddedCount).toBe(2)
+    expect(positions.size).toBe(3)
+    const c = positions.get('c')!
+    expect(Math.hypot(c[0], c[1], c[2])).toBeGreaterThan(150)
+    expect(c).not.toEqual([0, 0, 0])
+  })
+
+  it('reports embeddedCount 0 when no node carries an embedding', () => {
+    const nodes = [node('a'), node('b'), node('c')]
+    const { positions, embeddedCount } = projectNodesTo3D(nodes)
+    expect(embeddedCount).toBe(0)
+    expect(positions.size).toBe(3)
+    for (const id of ['a', 'b', 'c']) {
+      const p = positions.get(id)!
+      expect(Math.hypot(p[0], p[1], p[2])).toBeGreaterThan(150)
     }
   })
 })

--- a/webapp/src/components/hcg-explorer/clustering/embedding-service.ts
+++ b/webapp/src/components/hcg-explorer/clustering/embedding-service.ts
@@ -191,6 +191,52 @@ export function projectTo3D(
 }
 
 /**
+ * Project a set of graph nodes to 3D positions from their stored embeddings.
+ * Embedded nodes are placed by {@link projectTo3D} (UMAP / linear fallback);
+ * nodes without an embedding are placed on a deterministic golden-spiral shell
+ * just outside the embedding cloud so they stay visible and distinct. The
+ * returned `embeddedCount` lets callers fall back to a force layout when too
+ * few nodes carry embeddings for a meaningful projection.
+ */
+export function projectNodesTo3D(nodes: GraphNode[]): {
+  positions: Map<string, [number, number, number]>
+  embeddedCount: number
+} {
+  const embeddings = new Map<string, number[]>()
+  for (const n of nodes) {
+    if (Array.isArray(n.embedding) && n.embedding.length > 0) {
+      embeddings.set(n.id, n.embedding)
+    }
+  }
+
+  const projected = projectTo3D(embeddings)
+  const positions = new Map<string, [number, number, number]>()
+  for (const [id, p] of projected) {
+    positions.set(id, [p.x, p.y, p.z])
+  }
+
+  // Deterministic golden-spiral shell for nodes lacking an embedding, so they
+  // remain visible (and clearly outside the embedding cloud) rather than all
+  // collapsing to the origin.
+  const unembedded = nodes.filter(n => !positions.has(n.id))
+  const shell = LAYOUT_EXTENT * 1.6
+  const golden = Math.PI * (3 - Math.sqrt(5))
+  unembedded.forEach((n, i) => {
+    const t = unembedded.length > 1 ? i / (unembedded.length - 1) : 0
+    const y = 1 - 2 * t
+    const r = Math.sqrt(Math.max(0, 1 - y * y))
+    const theta = golden * i
+    positions.set(n.id, [
+      Math.cos(theta) * r * shell,
+      y * shell,
+      Math.sin(theta) * r * shell,
+    ])
+  })
+
+  return { positions, embeddedCount: embeddings.size }
+}
+
+/**
  * Center 3D coordinates on the origin, then map each point's radius through a
  * convex power curve, (r / rMax)^LAYOUT_GAMMA, before scaling out to `extent`.
  *

--- a/webapp/src/components/hcg-explorer/renderers/CytoscapeRenderer.tsx
+++ b/webapp/src/components/hcg-explorer/renderers/CytoscapeRenderer.tsx
@@ -13,6 +13,10 @@ import { NODE_COLORS, STATUS_COLORS } from '../types'
 // Register dagre layout
 cytoscape.use(dagre)
 
+/** Realm-root type names; the hierarchical layout roots the IS_A tree on the
+ *  type-definition nodes for these realms. */
+const REALM_ROOTS = new Set(['entity', 'concept', 'process'])
+
 /** Cytoscape stylesheet */
 function getStylesheet(): cytoscape.StylesheetJson {
   return [
@@ -227,11 +231,30 @@ function getStylesheet(): cytoscape.StylesheetJson {
         width: 3,
       },
     },
+    // Highlight-subgraph dimming: nodes/edges outside the focused subgraph
+    // fade back so a selection is emphasised without removing context.
+    {
+      selector: 'node.dimmed',
+      style: {
+        opacity: 0.12,
+        'text-opacity': 0.08,
+      },
+    },
+    {
+      selector: 'edge.dimmed',
+      style: {
+        opacity: 0.05,
+        'text-opacity': 0,
+      },
+    },
   ] as cytoscape.StylesheetJson
 }
 
 /** Layout configurations */
-function getLayoutConfig(layout: LayoutType): cytoscape.LayoutOptions {
+function getLayoutConfig(
+  layout: LayoutType,
+  cy?: Core
+): cytoscape.LayoutOptions {
   switch (layout) {
     case 'dagre':
       return {
@@ -298,6 +321,23 @@ function getLayoutConfig(layout: LayoutType): cytoscape.LayoutOptions {
         avoidOverlap: true,
       }
 
+    case 'hierarchical': {
+      // Top-down IS_A tree rooted at the realm-root type definitions
+      // (entity / concept / process). Uses cytoscape's built-in breadthfirst
+      // so no new dependency is needed; falls back to auto-picked roots when
+      // the realm roots are absent (e.g. a non-skeleton view).
+      const roots = cy ? cy.nodes('[?isRealmRoot]') : undefined
+      return {
+        name: 'breadthfirst',
+        directed: true,
+        roots: roots && roots.length > 0 ? roots : undefined,
+        spacingFactor: 1.4,
+        avoidOverlap: true,
+        animate: true,
+        animationDuration: 500,
+      } as cytoscape.LayoutOptions
+    }
+
     default:
       return {
         name: 'dagre',
@@ -317,6 +357,7 @@ export function CytoscapeRenderer({
   onNodeSelect,
   onNodeHover,
   layout,
+  highlightedNodeIds,
 }: RendererProps) {
   // hoveredNodeId handled via CSS classes, not direct state
   const containerRef = useRef<HTMLDivElement>(null)
@@ -379,6 +420,10 @@ export function CytoscapeRenderer({
         label: node.label.length > 20 ? node.label.slice(0, 20) + '...' : node.label,
         type: node.type,
         status: node.status,
+        // Realm-root flag drives the hierarchical layout roots.
+        isRealmRoot:
+          node.type === 'type_definition' &&
+          REALM_ROOTS.has(node.label.trim().toLowerCase()),
       },
     }))
 
@@ -440,7 +485,7 @@ export function CytoscapeRenderer({
     if (structuralChange) {
       if (layoutTimerRef.current) clearTimeout(layoutTimerRef.current)
       layoutTimerRef.current = setTimeout(() => {
-        const layoutConfig = getLayoutConfig(layout)
+        const layoutConfig = getLayoutConfig(layout, cy)
         cy.layout(
           layoutConfig.name === 'null'
             ? layoutConfig
@@ -468,6 +513,31 @@ export function CytoscapeRenderer({
       }
     }
   }, [selectedNodeId, isInitialized])
+
+  // Highlight-subgraph dimming: when a highlight set is active, keep those
+  // nodes (and edges with both endpoints in the set) bright and dim the rest,
+  // preserving context. A null/empty set clears all dimming (full opacity).
+  useEffect(() => {
+    if (!cyRef.current || !isInitialized) return
+    const cy = cyRef.current
+    const hi = highlightedNodeIds
+    if (!hi || hi.size === 0) {
+      cy.nodes().removeClass('dimmed')
+      cy.edges().removeClass('dimmed')
+      return
+    }
+    cy.nodes().forEach(n => {
+      if (hi.has(n.id())) n.removeClass('dimmed')
+      else n.addClass('dimmed')
+    })
+    cy.edges().forEach(e => {
+      if (hi.has(e.source().id()) && hi.has(e.target().id())) {
+        e.removeClass('dimmed')
+      } else {
+        e.addClass('dimmed')
+      }
+    })
+  }, [highlightedNodeIds, graph, isInitialized])
 
   // Fit view on initial load
   useEffect(() => {

--- a/webapp/src/components/hcg-explorer/renderers/CytoscapeRenderer.tsx
+++ b/webapp/src/components/hcg-explorer/renderers/CytoscapeRenderer.tsx
@@ -271,13 +271,16 @@ function getLayoutConfig(layout: LayoutType): cytoscape.LayoutOptions {
         avoidOverlap: true,
         minNodeSpacing: 50,
         concentric: (node: NodeSingular) => {
-          // Order by type: goal > plan > agent > step > process > state
+          // Order by type: goal > plan > agent > step > {process, entity, concept} > state
           const typeOrder: Record<string, number> = {
             goal: 5,
             plan: 4,
             agent: 3,
             step: 2,
+            // NDT realm types (entity/concept/process) are peers and share a ring level
             process: 1,
+            entity: 1,
+            concept: 1,
             state: 0,
           }
           return typeOrder[node.data('type')] ?? 0

--- a/webapp/src/components/hcg-explorer/renderers/CytoscapeRenderer.tsx
+++ b/webapp/src/components/hcg-explorer/renderers/CytoscapeRenderer.tsx
@@ -546,21 +546,25 @@ export function CytoscapeRenderer({
     if (!cyRef.current || !isInitialized) return
     const cy = cyRef.current
     const hi = highlightedNodeIds
-    if (!hi || hi.size === 0) {
-      cy.nodes().removeClass('dimmed')
-      cy.edges().removeClass('dimmed')
-      return
-    }
-    cy.nodes().forEach(n => {
-      if (hi.has(n.id())) n.removeClass('dimmed')
-      else n.addClass('dimmed')
-    })
-    cy.edges().forEach(e => {
-      if (hi.has(e.source().id()) && hi.has(e.target().id())) {
-        e.removeClass('dimmed')
-      } else {
-        e.addClass('dimmed')
+    // Batch the per-element class toggles so Cytoscape recalculates style/layout
+    // once instead of thrashing on every node and edge in the hairball.
+    cy.batch(() => {
+      if (!hi || hi.size === 0) {
+        cy.nodes().removeClass('dimmed')
+        cy.edges().removeClass('dimmed')
+        return
       }
+      cy.nodes().forEach(n => {
+        if (hi.has(n.id())) n.removeClass('dimmed')
+        else n.addClass('dimmed')
+      })
+      cy.edges().forEach(e => {
+        if (hi.has(e.source().id()) && hi.has(e.target().id())) {
+          e.removeClass('dimmed')
+        } else {
+          e.addClass('dimmed')
+        }
+      })
     })
   }, [highlightedNodeIds, graph, isInitialized])
 

--- a/webapp/src/components/hcg-explorer/renderers/CytoscapeRenderer.tsx
+++ b/webapp/src/components/hcg-explorer/renderers/CytoscapeRenderer.tsx
@@ -8,6 +8,12 @@ import { useEffect, useRef, useState } from 'react'
 import cytoscape, { Core, NodeSingular, EventObject } from 'cytoscape'
 import dagre from 'cytoscape-dagre'
 import type { RendererProps, LayoutType } from '../types'
+import {
+  DEFAULT_DENSITY,
+  densityToFcose,
+  densitySpacingFactor,
+  type DensityParams,
+} from '../utils/layout-density'
 import { NODE_COLORS, STATUS_COLORS } from '../types'
 
 // Register dagre layout
@@ -253,15 +259,22 @@ function getStylesheet(): cytoscape.StylesheetJson {
 /** Layout configurations */
 function getLayoutConfig(
   layout: LayoutType,
-  cy?: Core
+  cy?: Core,
+  densityParams: DensityParams = DEFAULT_DENSITY
 ): cytoscape.LayoutOptions {
+  // Density controls: fcose force layout uses the full mapping; non-force
+  // layouts (hierarchical / tree / circle / concentric / dagre) honour only the
+  // spacing (link-distance) slider.
+  const spacing = densitySpacingFactor(densityParams)
+  const spacingScale = spacing / 1.4
+  const fcose = densityToFcose(densityParams)
   switch (layout) {
     case 'dagre':
       return {
         name: 'dagre',
         rankDir: 'TB',
-        nodeSep: 60,
-        rankSep: 80,
+        nodeSep: Math.round(60 * spacingScale),
+        rankSep: Math.round(80 * spacingScale),
         animate: true,
         animationDuration: 500,
       } as cytoscape.LayoutOptions
@@ -272,9 +285,9 @@ function getLayoutConfig(
         animate: true,
         animationDuration: 500,
         nodeDimensionsIncludeLabels: true,
-        idealEdgeLength: 100,
-        nodeRepulsion: 4500,
-        gravity: 0.25,
+        idealEdgeLength: fcose.idealEdgeLength,
+        nodeRepulsion: fcose.nodeRepulsion,
+        gravity: fcose.gravity,
       } as cytoscape.LayoutOptions
 
     case 'circle':
@@ -283,7 +296,7 @@ function getLayoutConfig(
         animate: true,
         animationDuration: 500,
         avoidOverlap: true,
-        spacingFactor: 1.5,
+        spacingFactor: spacing,
       }
 
     case 'concentric':
@@ -292,7 +305,7 @@ function getLayoutConfig(
         animate: true,
         animationDuration: 500,
         avoidOverlap: true,
-        minNodeSpacing: 50,
+        minNodeSpacing: Math.round(50 * spacingScale),
         concentric: (node: NodeSingular) => {
           // Order by type: goal > plan > agent > step > {process, entity, concept} > state
           const typeOrder: Record<string, number> = {
@@ -317,7 +330,7 @@ function getLayoutConfig(
         animate: true,
         animationDuration: 500,
         directed: true,
-        spacingFactor: 1.5,
+        spacingFactor: spacing,
         avoidOverlap: true,
       }
 
@@ -331,7 +344,7 @@ function getLayoutConfig(
         name: 'breadthfirst',
         directed: true,
         roots: roots && roots.length > 0 ? roots : undefined,
-        spacingFactor: 1.4,
+        spacingFactor: spacing,
         avoidOverlap: true,
         animate: true,
         animationDuration: 500,
@@ -342,8 +355,8 @@ function getLayoutConfig(
       return {
         name: 'dagre',
         rankDir: 'TB',
-        nodeSep: 60,
-        rankSep: 80,
+        nodeSep: Math.round(60 * spacingScale),
+        rankSep: Math.round(80 * spacingScale),
         animate: true,
       } as cytoscape.LayoutOptions
   }
@@ -358,6 +371,7 @@ export function CytoscapeRenderer({
   onNodeHover,
   layout,
   highlightedNodeIds,
+  densityParams = DEFAULT_DENSITY,
 }: RendererProps) {
   // hoveredNodeId handled via CSS classes, not direct state
   const containerRef = useRef<HTMLDivElement>(null)
@@ -366,6 +380,10 @@ export function CytoscapeRenderer({
 
   // Track layout debounce timer
   const layoutTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // Track the last applied layout / density so the element-sync effect can
+  // re-run the layout when those controls change, not only on structural change.
+  const prevLayoutRef = useRef<LayoutType | null>(null)
+  const prevDensityRef = useRef<DensityParams | null>(null)
 
   // Initialize Cytoscape instance
   useEffect(() => {
@@ -481,19 +499,26 @@ export function CytoscapeRenderer({
       }
     })
 
-    // Only re-layout on structural changes, debounced
-    if (structuralChange) {
+    // Re-layout on structural changes OR when the layout / density controls
+    // change, so switching layout or moving a density slider takes effect
+    // immediately instead of waiting for the next snapshot poll (which is what
+    // made the layout button feel like a no-op). Debounced to coalesce drags.
+    const layoutChanged = prevLayoutRef.current !== layout
+    const densityChanged = prevDensityRef.current !== densityParams
+    prevLayoutRef.current = layout
+    prevDensityRef.current = densityParams
+    if (structuralChange || layoutChanged || densityChanged) {
       if (layoutTimerRef.current) clearTimeout(layoutTimerRef.current)
       layoutTimerRef.current = setTimeout(() => {
-        const layoutConfig = getLayoutConfig(layout, cy)
+        const layoutConfig = getLayoutConfig(layout, cy, densityParams)
         cy.layout(
           layoutConfig.name === 'null'
             ? layoutConfig
             : ({ ...layoutConfig, fit: false } as cytoscape.LayoutOptions)
         ).run()
-      }, 300)
+      }, 200)
     }
-  }, [graph, layout, isInitialized])
+  }, [graph, layout, densityParams, isInitialized])
 
   // Handle selection changes
   useEffect(() => {

--- a/webapp/src/components/hcg-explorer/renderers/ThreeRenderer.tsx
+++ b/webapp/src/components/hcg-explorer/renderers/ThreeRenderer.tsx
@@ -178,7 +178,24 @@ const EdgeLine = memo(function EdgeLine({ sourcePos, targetPos, label, dimmed }:
       ) : null}
     </group>
   )
-})
+}, edgeLinePropsEqual)
+
+// sourcePos/targetPos are fresh arrays on every simulation tick, so the default
+// shallow memo comparison never matches and EdgeLine re-renders every frame.
+// Compare coordinate values instead, so an edge only re-renders when it actually
+// moved (or its label/dimmed state changed) — a no-op once the layout settles.
+function edgeLinePropsEqual(prev: EdgeLineProps, next: EdgeLineProps): boolean {
+  return (
+    prev.dimmed === next.dimmed &&
+    prev.label === next.label &&
+    prev.sourcePos[0] === next.sourcePos[0] &&
+    prev.sourcePos[1] === next.sourcePos[1] &&
+    prev.sourcePos[2] === next.sourcePos[2] &&
+    prev.targetPos[0] === next.targetPos[0] &&
+    prev.targetPos[1] === next.targetPos[1] &&
+    prev.targetPos[2] === next.targetPos[2]
+  )
+}
 
 /** Scene content with nodes and edges */
 interface SceneContentProps {

--- a/webapp/src/components/hcg-explorer/renderers/ThreeRenderer.tsx
+++ b/webapp/src/components/hcg-explorer/renderers/ThreeRenderer.tsx
@@ -34,6 +34,7 @@ interface NodeSphereProps {
   position: [number, number, number]
   isSelected: boolean
   isHovered: boolean
+  dimmed: boolean
   onSelect: (id: string) => void
   onHover: (id: string | null) => void
 }
@@ -43,6 +44,7 @@ const NodeSphere = memo(function NodeSphere({
   position,
   isSelected,
   isHovered,
+  dimmed,
   onSelect,
   onHover,
 }: NodeSphereProps) {
@@ -88,6 +90,8 @@ const NodeSphere = memo(function NodeSphere({
           color={baseColor}
           emissive={isSelected ? baseColor : '#000000'}
           emissiveIntensity={isSelected ? 0.3 : 0}
+          transparent={dimmed}
+          opacity={dimmed ? 0.1 : 1}
         />
       </mesh>
 
@@ -107,6 +111,7 @@ const NodeSphere = memo(function NodeSphere({
       <Text
         position={[0, 8, 0]}
         fontSize={3}
+        fillOpacity={dimmed ? 0.08 : 1}
         color="#ffffff"
         anchorX="center"
         anchorY="bottom"
@@ -124,9 +129,10 @@ interface EdgeLineProps {
   sourcePos: [number, number, number]
   targetPos: [number, number, number]
   label: string
+  dimmed: boolean
 }
 
-const EdgeLine = memo(function EdgeLine({ sourcePos, targetPos, label }: EdgeLineProps) {
+const EdgeLine = memo(function EdgeLine({ sourcePos, targetPos, label, dimmed }: EdgeLineProps) {
   // Midpoint anchors both the connector marker and the relation label.
   const midpoint: [number, number, number] = [
     (sourcePos[0] + targetPos[0]) / 2,
@@ -140,13 +146,15 @@ const EdgeLine = memo(function EdgeLine({ sourcePos, targetPos, label }: EdgeLin
         points={[sourcePos, targetPos]}
         color="#666666"
         lineWidth={1}
-        opacity={0.6}
+        opacity={dimmed ? 0.05 : 0.6}
         transparent
       />
-      {/* Connector marker near midpoint */}
-      <mesh position={midpoint} geometry={SHARED_MIDPOINT_GEO} material={SHARED_MIDPOINT_MAT} />
-      {/* Relation label (the edge_type) */}
-      {label ? (
+      {/* Connector marker near midpoint (hidden when dimmed) */}
+      {!dimmed && (
+        <mesh position={midpoint} geometry={SHARED_MIDPOINT_GEO} material={SHARED_MIDPOINT_MAT} />
+      )}
+      {/* Relation label (the edge_type), hidden when dimmed */}
+      {label && !dimmed ? (
         <Text
           position={[midpoint[0], midpoint[1] + 3, midpoint[2]]}
           fontSize={2.2}
@@ -171,6 +179,7 @@ interface SceneContentProps {
   hoveredNodeId: string | null
   onNodeSelect: (id: string | null) => void
   onNodeHover: (id: string | null) => void
+  highlightedNodeIds?: Set<string> | null
 }
 
 function SceneContent({
@@ -180,6 +189,7 @@ function SceneContent({
   hoveredNodeId,
   onNodeSelect,
   onNodeHover,
+  highlightedNodeIds,
 }: SceneContentProps) {
   const [positions, setPositions] = useState<Map<string, [number, number, number]>>(
     new Map()
@@ -329,6 +339,13 @@ function SceneContent({
             sourcePos={sourcePos}
             targetPos={targetPos}
             label={edge.label}
+            dimmed={
+              !!highlightedNodeIds &&
+              !(
+                highlightedNodeIds.has(edge.source) &&
+                highlightedNodeIds.has(edge.target)
+              )
+            }
           />
         )
       })}
@@ -347,6 +364,7 @@ function SceneContent({
             isHovered={hoveredNodeId === node.id}
             onSelect={onNodeSelect}
             onHover={onNodeHover}
+            dimmed={!!highlightedNodeIds && !highlightedNodeIds.has(node.id)}
           />
         )
       })}
@@ -415,6 +433,7 @@ export function ThreeRenderer({
   hoveredNodeId,
   onNodeSelect,
   onNodeHover,
+  highlightedNodeIds,
 }: RendererProps) {
   return (
     <Canvas
@@ -434,6 +453,7 @@ export function ThreeRenderer({
         hoveredNodeId={hoveredNodeId}
         onNodeSelect={onNodeSelect}
         onNodeHover={onNodeHover}
+        highlightedNodeIds={highlightedNodeIds}
       />
 
       {/* Grid helper for orientation */}

--- a/webapp/src/components/hcg-explorer/renderers/ThreeRenderer.tsx
+++ b/webapp/src/components/hcg-explorer/renderers/ThreeRenderer.tsx
@@ -15,9 +15,18 @@ import {
   forceLink,
   forceCenter,
   forceCollide,
+  forceX,
+  forceY,
+  forceZ,
 } from 'd3-force-3d'
-import type { RendererProps, GraphNode, GraphEdge } from '../types'
+import type { RendererProps, GraphNode, GraphEdge, LayoutType } from '../types'
 import { NODE_COLORS, STATUS_COLORS } from '../types'
+import { projectNodesTo3D } from '../clustering/embedding-service'
+import {
+  DEFAULT_DENSITY,
+  densityToForce3D,
+  type DensityParams,
+} from '../utils/layout-density'
 
 /* ── Shared geometry & material singletons (allocated once) ── */
 const SHARED_SPHERE_GEO = new THREE.SphereGeometry(5, 16, 16)
@@ -180,6 +189,8 @@ interface SceneContentProps {
   onNodeSelect: (id: string | null) => void
   onNodeHover: (id: string | null) => void
   highlightedNodeIds?: Set<string> | null
+  layout: LayoutType
+  densityParams: DensityParams
 }
 
 function SceneContent({
@@ -190,6 +201,8 @@ function SceneContent({
   onNodeSelect,
   onNodeHover,
   highlightedNodeIds,
+  layout,
+  densityParams,
 }: SceneContentProps) {
   const [positions, setPositions] = useState<Map<string, [number, number, number]>>(
     new Map()
@@ -209,6 +222,23 @@ function SceneContent({
       }
       setPositions(new Map())
       return
+    }
+
+    // Semantic layout: place nodes at their embedding projection instead of
+    // running the force simulation, so 'semantic' is visibly distinct from
+    // 'force-3d'. Falls back to force when too few nodes carry embeddings.
+    if (layout === 'semantic') {
+      const { positions: semanticPositions, embeddedCount } =
+        projectNodesTo3D(nodes)
+      if (embeddedCount >= 2) {
+        if (simulationRef.current) {
+          simulationRef.current.stop()
+          simulationRef.current = null
+        }
+        setPositions(semanticPositions)
+        return
+      }
+      // No usable embeddings in this snapshot — fall through to force layout.
     }
 
     const currentNodeMap = simNodesRef.current
@@ -267,15 +297,20 @@ function SceneContent({
       simulationRef.current.stop()
     }
 
+    const force = densityToForce3D(densityParams)
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const linkForce = forceLink(simLinks).id((d: any) => d.id) as any
-    if (linkForce.distance) linkForce.distance(50)
+    if (linkForce.distance) linkForce.distance(force.linkDistance)
 
     const simulation = forceSimulation(simNodes, 3)
-      .force('charge', forceManyBody().strength(-100))
+      .force('charge', forceManyBody().strength(force.chargeStrength))
       .force('link', linkForce)
       .force('center', forceCenter(0, 0, 0))
       .force('collide', forceCollide(10))
+      .force('x', forceX(0).strength(force.gravity))
+      .force('y', forceY(0).strength(force.gravity))
+      .force('z', forceZ(0).strength(force.gravity))
       .alphaDecay(0.02)
 
     simulationRef.current = simulation
@@ -294,7 +329,7 @@ function SceneContent({
     return () => {
       simulation.stop()
     }
-  }, [nodes, edges])
+  }, [nodes, edges, layout, densityParams])
 
   // Handle click on empty space to deselect
   const handleBackgroundClick = useCallback(() => {
@@ -434,6 +469,8 @@ export function ThreeRenderer({
   onNodeSelect,
   onNodeHover,
   highlightedNodeIds,
+  layout,
+  densityParams = DEFAULT_DENSITY,
 }: RendererProps) {
   return (
     <Canvas
@@ -454,6 +491,8 @@ export function ThreeRenderer({
         onNodeSelect={onNodeSelect}
         onNodeHover={onNodeHover}
         highlightedNodeIds={highlightedNodeIds}
+        layout={layout}
+        densityParams={densityParams}
       />
 
       {/* Grid helper for orientation */}

--- a/webapp/src/components/hcg-explorer/types.ts
+++ b/webapp/src/components/hcg-explorer/types.ts
@@ -17,8 +17,15 @@ export type LayoutType =
   | 'circle'     // Circular layout
   | 'concentric' // Concentric by type
   | 'breadthfirst' // BFS tree
+  | 'hierarchical' // Top-down IS_A tree rooted at realm roots (2D only)
   | 'force-3d'   // 3D force simulation
   | 'semantic'   // Embedding-based positioning
+
+/** Edge-kind toggle: IS_A membership only, semantic only, or both. */
+export type EdgeKindFilter = 'both' | 'is_a' | 'semantic'
+
+/** How a type/node selection is applied: dim others (highlight) or remove (restrict). */
+export type SelectionMode = 'highlight' | 'restrict'
 
 /** Node representation for rendering */
 export interface GraphNode {
@@ -90,6 +97,27 @@ export interface FilterConfig {
    * literals keep type-checking; treated as null when absent.
    */
   selectedTypeId?: string | null
+  /**
+   * De-hairball default: when true (the app default) the rendered graph is
+   * restricted to the type_definition skeleton: type nodes plus the type-to-type
+   * IS_A hierarchy. Optional so existing FilterConfig literals keep type-checking;
+   * treated as off when absent (preserves direct processGraph/buildGraph callers
+   * and the existing test fixtures).
+   */
+  skeletonOnly?: boolean
+  /**
+   * Which edge kinds to render: both (default), is_a (membership/hierarchy only)
+   * or semantic (everything that is not IS_A). Membership is the bulk of the edge
+   * density, so semantic noticeably thins the view. Treated as both when absent.
+   */
+  edgeKind?: EdgeKindFilter
+  /**
+   * How a type/node selection is applied. highlight (the app default) keeps
+   * context and dims the rest in the renderer; restrict is the prior hard filter
+   * that removes non-members in buildGraph. Absent is treated as restrict to
+   * preserve the original buildGraph type-filter behaviour.
+   */
+  selectionMode?: SelectionMode
 }
 
 /** Property filter definition */
@@ -172,6 +200,12 @@ export interface RendererProps {
   onNodeSelect: (id: string | null) => void
   onNodeHover: (id: string | null) => void
   layout: LayoutType
+  /**
+   * Ids of nodes in the highlighted subgraph. When set (non-null), renderers
+   * keep these nodes/edges at full opacity and dim everything else; an edge is
+   * highlighted only when both endpoints are in the set. Null = no dimming.
+   */
+  highlightedNodeIds?: Set<string> | null
 }
 
 /** Color scheme for entity types */
@@ -223,6 +257,10 @@ export const DEFAULT_FILTER_CONFIG: FilterConfig = {
   propertyFilters: [],
   clusters: [],
   selectedTypeId: null,
+  // De-hairball defaults: skeleton-first, all edge kinds, highlight-on-select.
+  skeletonOnly: true,
+  edgeKind: 'both',
+  selectionMode: 'highlight',
 }
 
 /** Default embedding configuration */

--- a/webapp/src/components/hcg-explorer/types.ts
+++ b/webapp/src/components/hcg-explorer/types.ts
@@ -3,6 +3,7 @@
  */
 
 import type { Entity, CausalEdge, GraphSnapshot } from '../../types/hcg'
+import type { DensityParams } from './utils/layout-density'
 
 // Re-export base types
 export type { Entity, CausalEdge, GraphSnapshot }
@@ -206,6 +207,8 @@ export interface RendererProps {
    * highlighted only when both endpoints are in the set. Null = no dimming.
    */
   highlightedNodeIds?: Set<string> | null
+  /** Force-layout density controls (repulsion / link distance / gravity). */
+  densityParams?: DensityParams
 }
 
 /** Color scheme for entity types */

--- a/webapp/src/components/hcg-explorer/utils/graph-processor.ts
+++ b/webapp/src/components/hcg-explorer/utils/graph-processor.ts
@@ -117,10 +117,16 @@ export function buildGraph(
   // Type membership is read from the ORIGINAL snapshot IS_A edges (not the
   // transformed one) so the selected-type filter is correct in both modes:
   // reification rewrites edges into FROM/TO and would otherwise lose IS_A.
-  const typeMemberIds = computeTypeMemberIds(
-    snapshot,
-    filterConfig.selectedTypeId ?? null
-  )
+  //
+  // The selection only RESTRICTS the graph in restrict mode. The default
+  // selection mode is highlight (context-preserving): the graph is left intact
+  // and the renderer dims non-members instead. When selectionMode is absent we
+  // keep the original restrict behaviour so direct buildGraph callers and the
+  // existing test fixtures are unaffected.
+  const restrict = filterConfig.selectionMode !== 'highlight'
+  const typeMemberIds = restrict
+    ? computeTypeMemberIds(snapshot, filterConfig.selectedTypeId ?? null)
+    : null
   return processGraph(transformed, filterConfig, typeMemberIds)
 }
 
@@ -182,6 +188,30 @@ export function computeTypeMemberIds(
 }
 
 /**
+ * Build the id set of the highlight subgraph for a focused node (type or
+ * instance): the focus node plus its 1-hop neighbourhood across all edge kinds
+ * (IS_A members/parents and semantic neighbours alike). Used to emphasise a
+ * subgraph in context, where the renderer dims everything outside this set
+ * without removing the rest of the graph. Returns null when nothing is focused.
+ *
+ * For a type-definition focus this yields the type, its IS_A members (edges
+ * targeting it), its child types and parent type; for an instance it yields the
+ * node, its type(s) and any semantically related nodes.
+ */
+export function computeHighlightSubgraphIds(
+  snapshot: GraphSnapshot,
+  focusId: string | null
+): Set<string> | null {
+  if (!focusId) return null
+  const ids = new Set<string>([focusId])
+  for (const e of snapshot.edges) {
+    if (e.source_id === focusId) ids.add(e.target_id)
+    else if (e.target_id === focusId) ids.add(e.source_id)
+  }
+  return ids
+}
+
+/**
  * Process a graph snapshot into renderable format
  */
 export function processGraph(
@@ -194,6 +224,15 @@ export function processGraph(
 
   // Convert edges
   let edges = snapshot.edges.map(edgeToGraphEdge)
+
+  // Skeleton-first (de-hairball): restrict to the type-definition skeleton.
+  // Keep only type-definition nodes; the type-to-type IS_A edges survive the
+  // edge-visibility filter below. This is the primary default for taming the
+  // ~3.8k-instance hairball down to the ~214-type IS_A skeleton.
+  const skeletonOnly = filterConfig.skeletonOnly === true
+  if (skeletonOnly) {
+    nodes = nodes.filter(n => n.type === 'type_definition')
+  }
 
   // Apply filters
   nodes = applyNodeFilters(nodes, filterConfig)
@@ -208,6 +247,21 @@ export function processGraph(
   // Filter edges to only include those with visible nodes
   const nodeIds = new Set(nodes.map(n => n.id))
   edges = edges.filter(e => nodeIds.has(e.source) && nodeIds.has(e.target))
+
+  // In skeleton mode keep only the type-to-type IS_A hierarchy edges (both
+  // endpoints are already type-definition nodes after the node restriction).
+  if (skeletonOnly) {
+    edges = edges.filter(e => e.type === 'IS_A')
+  }
+
+  // Edge-kind toggle: IS_A membership only, semantic (non-IS_A) only, or both.
+  // Membership (IS_A) is the bulk of the density, so semantic-only thins it out.
+  const edgeKind = filterConfig.edgeKind ?? 'both'
+  if (edgeKind === 'is_a') {
+    edges = edges.filter(e => e.type === 'IS_A')
+  } else if (edgeKind === 'semantic') {
+    edges = edges.filter(e => e.type !== 'IS_A')
+  }
 
   // Apply edge type filter
   if (filterConfig.edgeTypes.length > 0) {

--- a/webapp/src/components/hcg-explorer/utils/graph-processor.ts
+++ b/webapp/src/components/hcg-explorer/utils/graph-processor.ts
@@ -205,8 +205,16 @@ export function computeHighlightSubgraphIds(
   if (!focusId) return null
   const ids = new Set<string>([focusId])
   for (const e of snapshot.edges) {
-    if (e.source_id === focusId) ids.add(e.target_id)
-    else if (e.target_id === focusId) ids.add(e.source_id)
+    // Keep the other endpoint and, in reified mode, the edge-proxy node itself
+    // (rendered with id === e.id) so the proxy bridging the focus to its
+    // neighbour stays bright. Harmless in logical mode (no node has that id).
+    if (e.source_id === focusId) {
+      ids.add(e.target_id)
+      ids.add(e.id)
+    } else if (e.target_id === focusId) {
+      ids.add(e.source_id)
+      ids.add(e.id)
+    }
   }
   return ids
 }
@@ -256,11 +264,16 @@ export function processGraph(
 
   // Edge-kind toggle: IS_A membership only, semantic (non-IS_A) only, or both.
   // Membership (IS_A) is the bulk of the density, so semantic-only thins it out.
-  const edgeKind = filterConfig.edgeKind ?? 'both'
-  if (edgeKind === 'is_a') {
-    edges = edges.filter(e => e.type === 'IS_A')
-  } else if (edgeKind === 'semantic') {
-    edges = edges.filter(e => e.type !== 'IS_A')
+  // Skipped in skeleton mode: that already restricted edges to the type-to-type
+  // IS_A hierarchy above, so 'semantic' here would strip every edge and leave
+  // an edgeless skeleton.
+  if (!skeletonOnly) {
+    const edgeKind = filterConfig.edgeKind ?? 'both'
+    if (edgeKind === 'is_a') {
+      edges = edges.filter(e => e.type === 'IS_A')
+    } else if (edgeKind === 'semantic') {
+      edges = edges.filter(e => e.type !== 'IS_A')
+    }
   }
 
   // Apply edge type filter

--- a/webapp/src/components/hcg-explorer/utils/layout-density.test.ts
+++ b/webapp/src/components/hcg-explorer/utils/layout-density.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Tests for the layout-density param mapping (force-3d + fcose + spacing).
+ */
+
+import { describe, it, expect } from "vitest"
+import {
+  DEFAULT_DENSITY,
+  DENSITY_RANGES,
+  densityToForce3D,
+  densityToFcose,
+  densitySpacingFactor,
+  type DensityParams,
+} from "./layout-density"
+
+const params = (p: Partial<DensityParams>): DensityParams => ({
+  ...DEFAULT_DENSITY,
+  ...p,
+})
+
+describe("densityToForce3D", () => {
+  it("maps the defaults to the historical d3-force-3d settings", () => {
+    const f = densityToForce3D(DEFAULT_DENSITY)
+    expect(f.chargeStrength).toBe(-100)
+    expect(f.linkDistance).toBe(50)
+    expect(f.gravity).toBe(0.1)
+  })
+
+  it("negates the repulsion magnitude into a repulsive charge", () => {
+    expect(densityToForce3D(params({ repulsion: 250 })).chargeStrength).toBe(-250)
+  })
+
+  it("clamps repulsion / link distance / gravity into range", () => {
+    const high = densityToForce3D(
+      params({ repulsion: 9999, linkDistance: 9999, gravity: 9 })
+    )
+    expect(high.chargeStrength).toBe(-DENSITY_RANGES.repulsion.max)
+    expect(high.linkDistance).toBe(DENSITY_RANGES.linkDistance.max)
+    expect(high.gravity).toBe(DENSITY_RANGES.gravity.max)
+
+    const low = densityToForce3D(
+      params({ repulsion: -50, linkDistance: -1, gravity: -1 })
+    )
+    expect(low.chargeStrength).toBe(-DENSITY_RANGES.repulsion.min)
+    expect(low.linkDistance).toBe(DENSITY_RANGES.linkDistance.min)
+    expect(low.gravity).toBe(DENSITY_RANGES.gravity.min)
+  })
+
+  it("falls back to the minimum for NaN input", () => {
+    expect(densityToForce3D(params({ repulsion: NaN })).chargeStrength).toBe(
+      -DENSITY_RANGES.repulsion.min
+    )
+  })
+})
+
+describe("densityToFcose", () => {
+  it("maps the defaults to the historical fcose settings", () => {
+    const f = densityToFcose(DEFAULT_DENSITY)
+    expect(f.nodeRepulsion).toBe(4500)
+    expect(f.idealEdgeLength).toBe(100)
+    expect(f.gravity).toBe(0.1)
+  })
+
+  it("scales repulsion and link distance", () => {
+    const f = densityToFcose(params({ repulsion: 200, linkDistance: 100 }))
+    expect(f.nodeRepulsion).toBe(9000)
+    expect(f.idealEdgeLength).toBe(200)
+  })
+})
+
+describe("densitySpacingFactor", () => {
+  it("maps the default link distance to ~1.4", () => {
+    expect(densitySpacingFactor(DEFAULT_DENSITY)).toBeCloseTo(1.4)
+  })
+
+  it("grows with link distance and stays within bounds", () => {
+    expect(densitySpacingFactor(params({ linkDistance: 100 }))).toBeCloseTo(2.8)
+    expect(
+      densitySpacingFactor(params({ linkDistance: 10 }))
+    ).toBeGreaterThanOrEqual(0.5)
+    expect(
+      densitySpacingFactor(params({ linkDistance: 300 }))
+    ).toBeLessThanOrEqual(4)
+  })
+})

--- a/webapp/src/components/hcg-explorer/utils/layout-density.ts
+++ b/webapp/src/components/hcg-explorer/utils/layout-density.ts
@@ -1,0 +1,94 @@
+/**
+ * Layout density parameters shared by the 3D force renderer (d3-force-3d) and
+ * the 2D Cytoscape force layout (fcose). The sliders in HCGExplorer drive these
+ * values; the mapping helpers translate them into per-renderer force settings
+ * so a single set of controls re-lays-out both views consistently.
+ */
+
+export interface DensityParams {
+  /** Node repulsion magnitude (higher = nodes pushed further apart). */
+  repulsion: number
+  /** Preferred edge length (higher = longer links / more spread). */
+  linkDistance: number
+  /** Centering/gravity strength toward the origin (0 = none, 1 = strong). */
+  gravity: number
+}
+
+/** Defaults reproduce the historical force settings: charge -100, link 50,
+ *  fcose nodeRepulsion 4500 / idealEdgeLength 100. Gravity is a new, mild pull. */
+export const DEFAULT_DENSITY: DensityParams = {
+  repulsion: 100,
+  linkDistance: 50,
+  gravity: 0.1,
+}
+
+export const DENSITY_RANGES: Record<
+  keyof DensityParams,
+  { min: number; max: number; step: number }
+> = {
+  repulsion: { min: 10, max: 500, step: 10 },
+  linkDistance: { min: 10, max: 300, step: 5 },
+  gravity: { min: 0, max: 1, step: 0.05 },
+}
+
+function clamp(value: number, min: number, max: number): number {
+  if (Number.isNaN(value)) return min
+  return Math.min(max, Math.max(min, value))
+}
+
+/** Map density params to d3-force-3d settings used by ThreeRenderer. */
+export function densityToForce3D(p: DensityParams): {
+  chargeStrength: number
+  linkDistance: number
+  gravity: number
+} {
+  const repulsion = clamp(
+    p.repulsion,
+    DENSITY_RANGES.repulsion.min,
+    DENSITY_RANGES.repulsion.max
+  )
+  return {
+    chargeStrength: -repulsion,
+    linkDistance: clamp(
+      p.linkDistance,
+      DENSITY_RANGES.linkDistance.min,
+      DENSITY_RANGES.linkDistance.max
+    ),
+    gravity: clamp(p.gravity, DENSITY_RANGES.gravity.min, DENSITY_RANGES.gravity.max),
+  }
+}
+
+/** Map density params to cytoscape fcose force-layout settings. */
+export function densityToFcose(p: DensityParams): {
+  nodeRepulsion: number
+  idealEdgeLength: number
+  gravity: number
+} {
+  return {
+    nodeRepulsion:
+      clamp(p.repulsion, DENSITY_RANGES.repulsion.min, DENSITY_RANGES.repulsion.max) *
+      45,
+    idealEdgeLength:
+      clamp(
+        p.linkDistance,
+        DENSITY_RANGES.linkDistance.min,
+        DENSITY_RANGES.linkDistance.max
+      ) * 2,
+    gravity: clamp(p.gravity, DENSITY_RANGES.gravity.min, DENSITY_RANGES.gravity.max),
+  }
+}
+
+/**
+ * Spacing factor for non-force 2D layouts (breadthfirst / hierarchical / circle
+ * / concentric). Only the link-distance (spacing) slider is meaningful for
+ * these; repulsion and gravity do not apply. Default link distance maps to the
+ * historical spacing factor of ~1.4.
+ */
+export function densitySpacingFactor(p: DensityParams): number {
+  const linkDistance = clamp(
+    p.linkDistance,
+    DENSITY_RANGES.linkDistance.min,
+    DENSITY_RANGES.linkDistance.max
+  )
+  return clamp((linkDistance / DEFAULT_DENSITY.linkDistance) * 1.4, 0.5, 4)
+}

--- a/webapp/src/components/hcg-explorer/utils/viewer-improvements.test.ts
+++ b/webapp/src/components/hcg-explorer/utils/viewer-improvements.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Tests for the de-hairball viewer improvements (graph-processor pure logic):
+ * skeleton-first restriction, edge-kind filtering, highlight-subgraph ids, and
+ * the highlight-vs-restrict selection-mode gate in buildGraph.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  processGraph,
+  buildGraph,
+  computeHighlightSubgraphIds,
+} from './graph-processor'
+import type { GraphSnapshot, FilterConfig, CausalEdge } from '../types'
+
+const baseFilter: FilterConfig = {
+  entityTypes: [],
+  edgeTypes: [],
+  status: [],
+  searchQuery: '',
+  propertyFilters: [],
+  clusters: [],
+  selectedTypeId: null,
+}
+
+function edge(
+  id: string,
+  source: string,
+  target: string,
+  edgeType: string
+): CausalEdge {
+  return {
+    id,
+    source_id: source,
+    target_id: target,
+    edge_type: edgeType,
+    properties: {},
+    weight: 1,
+    created_at: '',
+  }
+}
+
+// Post-NDT shape: a realm-root type def (entity), emergent type defs joined by
+// type-to-type IS_A, instances joined to types by member-to-type IS_A, plus a
+// semantic (non-IS_A) edge between two instances.
+const snap = (): GraphSnapshot => ({
+  entities: [
+    { id: 'type_entity', type: 'type_definition', name: 'entity', properties: {}, labels: [] },
+    { id: 'type_elem', type: 'type_definition', name: 'chemical element', properties: {}, labels: [] },
+    { id: 'type_metal', type: 'type_definition', name: 'metal', properties: {}, labels: [] },
+    { id: 'iron', type: 'entity', name: 'Iron', properties: {}, labels: [] },
+    { id: 'gold', type: 'entity', name: 'Gold', properties: {}, labels: [] },
+  ],
+  edges: [
+    edge('te1', 'type_elem', 'type_entity', 'IS_A'),
+    edge('te2', 'type_metal', 'type_elem', 'IS_A'),
+    edge('me1', 'iron', 'type_metal', 'IS_A'),
+    edge('me2', 'gold', 'type_elem', 'IS_A'),
+    edge('se1', 'iron', 'gold', 'RELATED'),
+  ],
+  timestamp: '',
+  metadata: {},
+})
+
+describe('skeleton-first restriction', () => {
+  it('keeps only type_definition nodes when skeletonOnly is true', () => {
+    const g = processGraph(snap(), { ...baseFilter, skeletonOnly: true })
+    expect(g.nodes.every(n => n.type === 'type_definition')).toBe(true)
+    expect(g.nodes.map(n => n.id).sort()).toEqual([
+      'type_elem',
+      'type_entity',
+      'type_metal',
+    ])
+  })
+
+  it('keeps only type-to-type IS_A edges in the skeleton', () => {
+    const g = processGraph(snap(), { ...baseFilter, skeletonOnly: true })
+    expect(g.edges.every(e => e.type === 'IS_A')).toBe(true)
+    expect(g.edges.map(e => e.id).sort()).toEqual(['te1', 'te2'])
+  })
+
+  it('shows the full graph when skeletonOnly is false or absent', () => {
+    const g = processGraph(snap(), baseFilter)
+    expect(g.nodes).toHaveLength(5)
+    expect(g.edges).toHaveLength(5)
+  })
+
+  it('buildGraph applies the skeleton restriction too', () => {
+    const g = buildGraph(snap(), 'logical', { ...baseFilter, skeletonOnly: true })
+    expect(g.nodes.map(n => n.id).sort()).toEqual([
+      'type_elem',
+      'type_entity',
+      'type_metal',
+    ])
+    expect(g.edges.map(e => e.id).sort()).toEqual(['te1', 'te2'])
+  })
+})
+
+describe('edge-kind filtering', () => {
+  it('keeps every edge for both, the default', () => {
+    expect(processGraph(snap(), baseFilter).edges).toHaveLength(5)
+    expect(
+      processGraph(snap(), { ...baseFilter, edgeKind: 'both' }).edges
+    ).toHaveLength(5)
+  })
+
+  it('keeps only IS_A edges for is_a', () => {
+    const g = processGraph(snap(), { ...baseFilter, edgeKind: 'is_a' })
+    expect(g.edges.every(e => e.type === 'IS_A')).toBe(true)
+    expect(g.edges).toHaveLength(4)
+  })
+
+  it('keeps only non-IS_A edges for semantic', () => {
+    const g = processGraph(snap(), { ...baseFilter, edgeKind: 'semantic' })
+    expect(g.edges.map(e => e.id)).toEqual(['se1'])
+  })
+})
+
+describe('computeHighlightSubgraphIds', () => {
+  it('returns null when nothing is focused', () => {
+    expect(computeHighlightSubgraphIds(snap(), null)).toBeNull()
+  })
+
+  it('includes a type plus its members, child types and parent type', () => {
+    const ids = computeHighlightSubgraphIds(snap(), 'type_elem')!
+    expect([...ids].sort()).toEqual([
+      'gold',
+      'type_elem',
+      'type_entity',
+      'type_metal',
+    ])
+  })
+
+  it('includes an instance plus its type and semantic neighbours', () => {
+    const ids = computeHighlightSubgraphIds(snap(), 'iron')!
+    expect([...ids].sort()).toEqual(['gold', 'iron', 'type_metal'])
+  })
+})
+
+describe('selection-mode gate, highlight vs restrict', () => {
+  it('restricts to the selected type when selectionMode is absent', () => {
+    const g = buildGraph(snap(), 'logical', {
+      ...baseFilter,
+      selectedTypeId: 'type_elem',
+    })
+    expect(g.nodes.map(n => n.id).sort()).toEqual([
+      'gold',
+      'type_elem',
+      'type_metal',
+    ])
+  })
+
+  it('does not restrict in highlight mode, context preserved', () => {
+    const g = buildGraph(snap(), 'logical', {
+      ...baseFilter,
+      selectedTypeId: 'type_elem',
+      selectionMode: 'highlight',
+    })
+    expect(g.nodes).toHaveLength(5)
+  })
+})

--- a/webapp/src/components/hcg-explorer/utils/viewer-improvements.test.ts
+++ b/webapp/src/components/hcg-explorer/utils/viewer-improvements.test.ts
@@ -113,6 +113,18 @@ describe('edge-kind filtering', () => {
     const g = processGraph(snap(), { ...baseFilter, edgeKind: 'semantic' })
     expect(g.edges.map(e => e.id)).toEqual(['se1'])
   })
+
+  it('ignores the edge-kind toggle in skeleton mode (no edgeless skeleton)', () => {
+    // Regression for B1: skeleton mode already restricts edges to the
+    // type-to-type IS_A hierarchy; edgeKind 'semantic' would otherwise strip
+    // those and leave the skeleton with nodes but no edges.
+    const g = processGraph(snap(), {
+      ...baseFilter,
+      skeletonOnly: true,
+      edgeKind: 'semantic',
+    })
+    expect(g.edges.map(e => e.id).sort()).toEqual(['te1', 'te2'])
+  })
 })
 
 describe('computeHighlightSubgraphIds', () => {
@@ -122,8 +134,14 @@ describe('computeHighlightSubgraphIds', () => {
 
   it('includes a type plus its members, child types and parent type', () => {
     const ids = computeHighlightSubgraphIds(snap(), 'type_elem')!
+    // Real nodes (the type, its parent/child types and direct members) plus the
+    // ids of the touching edges, which are the reified edge-proxy nodes; those
+    // are inert in logical mode (no node carries that id).
     expect([...ids].sort()).toEqual([
       'gold',
+      'me2',
+      'te1',
+      'te2',
       'type_elem',
       'type_entity',
       'type_metal',
@@ -132,7 +150,23 @@ describe('computeHighlightSubgraphIds', () => {
 
   it('includes an instance plus its type and semantic neighbours', () => {
     const ids = computeHighlightSubgraphIds(snap(), 'iron')!
-    expect([...ids].sort()).toEqual(['gold', 'iron', 'type_metal'])
+    expect([...ids].sort()).toEqual([
+      'gold',
+      'iron',
+      'me1',
+      'se1',
+      'type_metal',
+    ])
+  })
+
+  it('keeps the reified edge-proxy node bright (adds the touching edge id)', () => {
+    // Regression for I1: in reified mode each edge renders as a node with
+    // id === e.id sitting between its endpoints. If the focus touches that edge
+    // the proxy must be in the highlight set, otherwise it gets dimmed out from
+    // under its own endpoints. me1 = iron --IS_A--> type_metal.
+    const ids = computeHighlightSubgraphIds(snap(), 'type_metal')!
+    expect(ids.has('me1')).toBe(true)
+    expect(ids.has('te2')).toBe(true)
   })
 })
 

--- a/webapp/src/types/d3-force-3d.d.ts
+++ b/webapp/src/types/d3-force-3d.d.ts
@@ -115,15 +115,36 @@ declare module 'd3-force-3d' {
 
   export function forceX<N extends SimulationNode = SimulationNode>(
     x?: number | ((node: N) => number)
-  ): Force<N, SimulationLink<N>>
+  ): Force<N, SimulationLink<N>> & {
+    x(): number | ((node: N) => number)
+    x(x: number | ((node: N) => number)): Force<N, SimulationLink<N>>
+    strength(): number | ((node: N, i: number, nodes: N[]) => number)
+    strength(
+      strength: number | ((node: N, i: number, nodes: N[]) => number)
+    ): Force<N, SimulationLink<N>>
+  }
 
   export function forceY<N extends SimulationNode = SimulationNode>(
     y?: number | ((node: N) => number)
-  ): Force<N, SimulationLink<N>>
+  ): Force<N, SimulationLink<N>> & {
+    y(): number | ((node: N) => number)
+    y(y: number | ((node: N) => number)): Force<N, SimulationLink<N>>
+    strength(): number | ((node: N, i: number, nodes: N[]) => number)
+    strength(
+      strength: number | ((node: N, i: number, nodes: N[]) => number)
+    ): Force<N, SimulationLink<N>>
+  }
 
   export function forceZ<N extends SimulationNode = SimulationNode>(
     z?: number | ((node: N) => number)
-  ): Force<N, SimulationLink<N>>
+  ): Force<N, SimulationLink<N>> & {
+    z(): number | ((node: N) => number)
+    z(z: number | ((node: N) => number)): Force<N, SimulationLink<N>>
+    strength(): number | ((node: N, i: number, nodes: N[]) => number)
+    strength(
+      strength: number | ((node: N, i: number, nodes: N[]) => number)
+    ): Force<N, SimulationLink<N>>
+  }
 
   export function forceRadial<N extends SimulationNode = SimulationNode>(
     radius: number | ((node: N) => number),


### PR DESCRIPTION
## HCG explorer de-hairball bundle

With ~3,860 instance nodes and ~8,330 edges the explorer rendered as an opaque ball of yarn. The meaningful structure is the ~214-type IS_A skeleton. Every change serves: show the skeleton, reveal/emphasize detail on demand.

### 1. Skeleton-first default
- New FilterConfig.skeletonOnly, default true in DEFAULT_FILTER_CONFIG. When on, processGraph/buildGraph keep only type_definition nodes plus the type-to-type IS_A hierarchy.
- Sidebar View panel toggle: Skeleton only vs Full graph.

### 2. Highlight-subgraph on select, context-preserving
- Selecting a type from the Types panel or clicking any node computes its subgraph via computeHighlightSubgraphIds / computeTypeMemberIds and renders it at full opacity while dimming the rest to about 0.1 opacity instead of removing it.
- highlightedNodeIds is threaded into both ThreeRenderer and CytoscapeRenderer; an edge stays bright only when both endpoints are highlighted. Clearing the selection restores full opacity.
- Highlight is the default interaction; the prior #188 restrict filter stays available via the Select: Restrict toggle, backed by FilterConfig.selectionMode.

### 3. Hierarchical layout, 2D only
- New hierarchical Cytoscape layout: a top-down breadthfirst IS_A tree rooted at the realm-root type definitions entity / concept / process. No new dependency. Wired into the 2D layout picker as IS_A Tree. 3D layouts unchanged.

### 4. Edge-type toggle
- New FilterConfig.edgeKind with values both, is_a, semantic, default both. Membership IS_A is the bulk of the density, so Semantic thins the view noticeably.

### Plus
- The concentric-layout fix already on the branch: group entity/concept with process on ring level 1.

### Defaults
- skeletonOnly true, edgeKind both, selectionMode highlight.

### Backward compatibility
- All new FilterConfig fields are optional; processGraph/buildGraph defaults preserve existing callers and the 13 existing test call sites.

### Verification, cwd webapp/
- type-check: pass
- lint: pass, 0 warnings
- vitest: 172 passed across 14 files, including 12 new in utils/viewer-improvements.test.ts
- build: success

### Left for visual tuning
- Exact dim opacity / desaturation values, hierarchical spacing, and View-panel styling. Behavior and defaults are set; aesthetics can be tuned later.
