### PR TITLE
fix(scripts): include redis in run_apollo.sh infra bring-up

### DIFF
--- a/scripts/run_apollo.sh
+++ b/scripts/run_apollo.sh
@@ -229,7 +229,7 @@ cd "${PROJECT_ROOT}"
 # Check infra (redundant if called from start_demo but good for standalone)
 if [[ -f "${DOCKER_COMPOSE_FILE}" ]]; then
     log_info "Ensuring infra containers are up..."
-    docker compose -f "${DOCKER_COMPOSE_FILE}" up -d --wait neo4j milvus-standalone >/dev/null 2>&1 || true
+    docker compose -f "${DOCKER_COMPOSE_FILE}" up -d --wait neo4j milvus-standalone redis >/dev/null 2>&1 || true
 fi
 
 # Start in dependency order: Sophia → Hermes → Apollo

--- a/scripts/run_apollo.sh
+++ b/scripts/run_apollo.sh
@@ -229,7 +229,8 @@ cd "${PROJECT_ROOT}"
 # Check infra (redundant if called from start_demo but good for standalone)
 if [[ -f "${DOCKER_COMPOSE_FILE}" ]]; then
     log_info "Ensuring infra containers are up..."
-    docker compose -f "${DOCKER_COMPOSE_FILE}" up -d --wait neo4j milvus-standalone redis >/dev/null 2>&1 || true
+    docker compose -f "${DOCKER_COMPOSE_FILE}" up -d --wait neo4j milvus-standalone redis >/dev/null 2>&1 \
+        || log_warn "Infra bring-up reported a problem (continuing; services may already be running)."
 fi
 
 # Start in dependency order: Sophia → Hermes → Apollo

--- a/scripts/start_demo.sh
+++ b/scripts/start_demo.sh
@@ -50,8 +50,8 @@ check_dependencies() {
 }
 
 start_infra() {
-    log_info "Ensuring Neo4j/Milvus/SHACL containers are running..."
-    docker compose -f "${DOCKER_COMPOSE_FILE}" up -d neo4j milvus-standalone shacl-validation
+    log_info "Ensuring Neo4j/Milvus/Redis/SHACL containers are running..."
+    docker compose -f "${DOCKER_COMPOSE_FILE}" up -d neo4j milvus-standalone redis shacl-validation
 
     # Start OTel observability stack
     local otel_compose="${LOGOS_ROOT}/infra/docker-compose.otel.yml"


### PR DESCRIPTION
The infra service list in `scripts/run_apollo.sh` predated redis joining `logos/infra/docker-compose.hcg.dev.yml`, so fresh environments came up without it — and since the line discards all output, nothing flagged the gap.

Downstream effect (2026-06-11 incident): sophia booted with EventBus + ProposalProcessor silently degraded, `/llm` ingestion dead while health stayed green, proposals accumulating unconsumed in `sophia:proposals:pending` (1,115 deep when found).

One-line fix: add `redis` to the `up -d --wait` service list. Verified end-to-end today: with redis up at sophia boot, the proof-lines appear (`ProposalProcessor initialized`, `Proposal processing worker initialized`) and a 16-block smoke ingest lands real nodes with the queue draining to 0.

Fixes #192