### PR TITLE
feat(apollo): scoped de-reified graph layer + apollo-cli graph commands

### DIFF
--- a/src/apollo/api/server.py
+++ b/src/apollo/api/server.py
@@ -736,6 +736,87 @@ async def get_graph_snapshot(
             )
 
 
+@app.get("/api/hcg/stats")
+async def get_graph_stats() -> Dict[str, Any]:
+    """Graph size/shape: content nodes vs reified edge-nodes, types, predicates."""
+    with tracer.start_as_current_span("apollo.api.hcg.stats") as span:
+        if not hcg_client:
+            raise HTTPException(status_code=503, detail="HCG client not available")
+        try:
+            return await asyncio.to_thread(hcg_client.get_graph_stats)
+        except Exception as e:
+            span.set_status(StatusCode.ERROR, str(e))
+            span.record_exception(e)
+            raise HTTPException(
+                status_code=500, detail=f"Failed to fetch graph stats: {str(e)}"
+            )
+
+
+@app.get("/api/hcg/types")
+async def get_type_summaries(
+    limit: int = Query(500, ge=1, le=2000, description="Maximum number of types"),
+) -> List[Dict[str, Any]]:
+    """The positional type layer (any IS_A target) with member counts + parent."""
+    with tracer.start_as_current_span("apollo.api.hcg.types") as span:
+        span.set_attribute("hcg.limit", limit)
+        if not hcg_client:
+            raise HTTPException(status_code=503, detail="HCG client not available")
+        try:
+            return await asyncio.to_thread(hcg_client.get_type_summaries, limit=limit)
+        except Exception as e:
+            span.set_status(StatusCode.ERROR, str(e))
+            span.record_exception(e)
+            raise HTTPException(
+                status_code=500, detail=f"Failed to fetch types: {str(e)}"
+            )
+
+
+@app.get("/api/hcg/neighborhood/{node_id}", response_model=GraphSnapshot)
+async def get_neighborhood(
+    node_id: str,
+    depth: int = Query(1, ge=1, le=4, description="Logical hops to expand"),
+    limit: int = Query(100, ge=1, le=1000, description="Maximum number of nodes"),
+) -> GraphSnapshot:
+    """De-reified logical neighborhood of a node, scoped by depth + limit."""
+    try:
+        node_id = validate_entity_id(node_id)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    with tracer.start_as_current_span("apollo.api.hcg.neighborhood") as span:
+        span.set_attribute("hcg.depth", depth)
+        if not hcg_client:
+            raise HTTPException(status_code=503, detail="HCG client not available")
+        try:
+            return await asyncio.to_thread(
+                hcg_client.get_neighborhood, node_id, depth=depth, limit=limit
+            )
+        except Exception as e:
+            span.set_status(StatusCode.ERROR, str(e))
+            span.record_exception(e)
+            raise HTTPException(
+                status_code=500, detail=f"Failed to fetch neighborhood: {str(e)}"
+            )
+
+
+@app.get("/api/hcg/search", response_model=List[Entity])
+async def search_nodes(
+    q: str = Query(..., min_length=1, description="Name or uuid to search for"),
+    limit: int = Query(25, ge=1, le=200, description="Maximum number of results"),
+) -> List[Entity]:
+    """Find content nodes by name (or exact uuid) — entry points for navigation."""
+    with tracer.start_as_current_span("apollo.api.hcg.search") as span:
+        if not hcg_client:
+            raise HTTPException(status_code=503, detail="HCG client not available")
+        try:
+            return await asyncio.to_thread(hcg_client.search_nodes, q, limit=limit)
+        except Exception as e:
+            span.set_status(StatusCode.ERROR, str(e))
+            span.record_exception(e)
+            raise HTTPException(
+                status_code=500, detail=f"Failed to search nodes: {str(e)}"
+            )
+
+
 @app.post("/api/chat/stream")
 async def chat_stream(request: ChatStreamRequest) -> StreamingResponse:
     """Stream Hermes completions back to the client while logging telemetry/persona."""

--- a/src/apollo/cli/main.py
+++ b/src/apollo/cli/main.py
@@ -18,6 +18,7 @@ from apollo.client.sophia_client import SophiaClient
 from apollo.client.hermes_client import HermesClient, HermesResponse
 from apollo.client.persona_client import PersonaClient
 from apollo.config.settings import ApolloConfig, PersonaApiConfig
+from apollo.data.hcg_client import HCGClient
 
 import os
 
@@ -92,6 +93,7 @@ def cli(ctx: click.Context) -> None:
     ctx.obj["client"] = SophiaClient(ctx.obj["config"].sophia)
     ctx.obj["hermes"] = HermesClient(ctx.obj["config"].hermes)
     ctx.obj["persona"] = PersonaClient(ctx.obj["config"].persona_api)
+    ctx.obj["hcg"] = HCGClient(ctx.obj["config"].hcg.neo4j)
 
 
 @cli.command()
@@ -1018,6 +1020,117 @@ def _persona_api_base_url(config: PersonaApiConfig) -> str:
     if config.host.startswith(("http://", "https://")):
         return config.host.rstrip("/")
     return f"http://{config.host}:{config.port}"
+
+
+# ---------------------------------------------------------------------------
+# graph: interrogate the HCG directly (same scoped data the API serves; the CLI
+# imports HCGClient so it works with no API process running)
+# ---------------------------------------------------------------------------
+@cli.group()
+def graph() -> None:
+    """Query the HCG graph directly (same data the API serves)."""
+
+
+@graph.command("stats")
+@click.pass_context
+def graph_stats(ctx: click.Context) -> None:
+    """Graph size: content nodes vs reified edge-nodes, types, top predicates."""
+    hcg: HCGClient = ctx.obj["hcg"]
+    s = hcg.get_graph_stats()
+    console.print(
+        f"[bold]{s['total_nodes']}[/bold] nodes = "
+        f"[green]{s['content_nodes']} content[/green] + "
+        f"[dim]{s['edge_nodes']} edge-nodes[/dim]  |  "
+        f"{s['type_definitions']} type-definitions"
+    )
+    realms = Table(title="content by realm")
+    realms.add_column("realm")
+    realms.add_column("count", justify="right")
+    for realm, count in s["by_realm"].items():
+        realms.add_row(str(realm), str(count))
+    console.print(realms)
+    preds = Table(title="top predicates")
+    preds.add_column("predicate")
+    preds.add_column("count", justify="right")
+    for rel, count in s["top_predicates"].items():
+        preds.add_row(str(rel), str(count))
+    console.print(preds)
+
+
+@graph.command("types")
+@click.option("--limit", default=30, help="Maximum number of types to show")
+@click.pass_context
+def graph_types(ctx: click.Context, limit: int) -> None:
+    """The positional type layer with member counts and parent type."""
+    hcg: HCGClient = ctx.obj["hcg"]
+    table = Table(title="positional type layer")
+    table.add_column("type")
+    table.add_column("members", justify="right")
+    table.add_column("parent")
+    for row in hcg.get_type_summaries(limit=limit):
+        table.add_row(
+            row["name"] or "?", str(row["member_count"]), row["parent"] or "-"
+        )
+    console.print(table)
+
+
+@graph.command("search")
+@click.argument("query")
+@click.option("--limit", default=20, help="Maximum number of results")
+@click.pass_context
+def graph_search(ctx: click.Context, query: str, limit: int) -> None:
+    """Find nodes by name (or exact uuid) — entry points for navigation."""
+    hcg: HCGClient = ctx.obj["hcg"]
+    table = Table(title=f"search: {query!r}")
+    table.add_column("uuid")
+    table.add_column("name")
+    table.add_column("type")
+    for entity in hcg.search_nodes(query, limit=limit):
+        table.add_row(entity.id, str(entity.properties.get("name", "")), entity.type)
+    console.print(table)
+
+
+@graph.command("node")
+@click.argument("node_id")
+@click.pass_context
+def graph_node(ctx: click.Context, node_id: str) -> None:
+    """Show a single node (by uuid) and its properties."""
+    hcg: HCGClient = ctx.obj["hcg"]
+    entity = hcg.get_entity_by_id(node_id)
+    if not entity:
+        console.print(f"[red]not found:[/red] {node_id}")
+        return
+    body = yaml.safe_dump(entity.properties, sort_keys=False, default_flow_style=False)
+    console.print(
+        Panel(body, title=f"{entity.properties.get('name', '?')} ({entity.type})")
+    )
+
+
+@graph.command("neighbors")
+@click.argument("node_id")
+@click.option("--depth", default=1, help="Logical hops to expand")
+@click.option("--limit", default=50, help="Maximum number of nodes")
+@click.pass_context
+def graph_neighbors(ctx: click.Context, node_id: str, depth: int, limit: int) -> None:
+    """De-reified logical neighborhood of a node (src --predicate--> tgt)."""
+    hcg: HCGClient = ctx.obj["hcg"]
+    snap = hcg.get_neighborhood(node_id, depth=depth, limit=limit)
+    names = {e.id: e.properties.get("name", e.id[:8]) for e in snap.entities}
+    console.print(
+        f"[bold]{names.get(node_id, node_id)}[/bold] — {len(snap.entities)} nodes, "
+        f"{len(snap.edges)} logical edges (depth {depth})"
+    )
+    table = Table()
+    table.add_column("source")
+    table.add_column("predicate")
+    table.add_column("target")
+    for edge in snap.edges:
+        table.add_row(
+            str(names.get(edge.source_id, edge.source_id[:8])),
+            edge.edge_type,
+            str(names.get(edge.target_id, edge.target_id[:8])),
+        )
+    console.print(table)
 
 
 def main() -> None:

--- a/src/apollo/cli/main.py
+++ b/src/apollo/cli/main.py
@@ -93,7 +93,6 @@ def cli(ctx: click.Context) -> None:
     ctx.obj["client"] = SophiaClient(ctx.obj["config"].sophia)
     ctx.obj["hermes"] = HermesClient(ctx.obj["config"].hermes)
     ctx.obj["persona"] = PersonaClient(ctx.obj["config"].persona_api)
-    ctx.obj["hcg"] = HCGClient(ctx.obj["config"].hcg.neo4j)
 
 
 @cli.command()
@@ -1026,6 +1025,12 @@ def _persona_api_base_url(config: PersonaApiConfig) -> str:
 # graph: interrogate the HCG directly (same scoped data the API serves; the CLI
 # imports HCGClient so it works with no API process running)
 # ---------------------------------------------------------------------------
+def _hcg(ctx: click.Context) -> HCGClient:
+    """Build the HCG client lazily — only when a graph command actually runs,
+    so non-graph commands never require Neo4j config."""
+    return HCGClient(ctx.obj["config"].hcg.neo4j)
+
+
 @cli.group()
 def graph() -> None:
     """Query the HCG graph directly (same data the API serves)."""
@@ -1035,7 +1040,7 @@ def graph() -> None:
 @click.pass_context
 def graph_stats(ctx: click.Context) -> None:
     """Graph size: content nodes vs reified edge-nodes, types, top predicates."""
-    hcg: HCGClient = ctx.obj["hcg"]
+    hcg = _hcg(ctx)
     s = hcg.get_graph_stats()
     console.print(
         f"[bold]{s['total_nodes']}[/bold] nodes = "
@@ -1062,7 +1067,7 @@ def graph_stats(ctx: click.Context) -> None:
 @click.pass_context
 def graph_types(ctx: click.Context, limit: int) -> None:
     """The positional type layer with member counts and parent type."""
-    hcg: HCGClient = ctx.obj["hcg"]
+    hcg = _hcg(ctx)
     table = Table(title="positional type layer")
     table.add_column("type")
     table.add_column("members", justify="right")
@@ -1080,7 +1085,7 @@ def graph_types(ctx: click.Context, limit: int) -> None:
 @click.pass_context
 def graph_search(ctx: click.Context, query: str, limit: int) -> None:
     """Find nodes by name (or exact uuid) — entry points for navigation."""
-    hcg: HCGClient = ctx.obj["hcg"]
+    hcg = _hcg(ctx)
     table = Table(title=f"search: {query!r}")
     table.add_column("uuid")
     table.add_column("name")
@@ -1095,7 +1100,7 @@ def graph_search(ctx: click.Context, query: str, limit: int) -> None:
 @click.pass_context
 def graph_node(ctx: click.Context, node_id: str) -> None:
     """Show a single node (by uuid) and its properties."""
-    hcg: HCGClient = ctx.obj["hcg"]
+    hcg = _hcg(ctx)
     entity = hcg.get_entity_by_id(node_id)
     if not entity:
         console.print(f"[red]not found:[/red] {node_id}")
@@ -1113,7 +1118,7 @@ def graph_node(ctx: click.Context, node_id: str) -> None:
 @click.pass_context
 def graph_neighbors(ctx: click.Context, node_id: str, depth: int, limit: int) -> None:
     """De-reified logical neighborhood of a node (src --predicate--> tgt)."""
-    hcg: HCGClient = ctx.obj["hcg"]
+    hcg = _hcg(ctx)
     snap = hcg.get_neighborhood(node_id, depth=depth, limit=limit)
     names = {e.id: e.properties.get("name", e.id[:8]) for e in snap.entities}
     console.print(

--- a/src/apollo/config/settings.py
+++ b/src/apollo/config/settings.py
@@ -30,6 +30,20 @@ def _get_client_host(env_var: str, default: str = "localhost") -> str:
     return "localhost" if host == "0.0.0.0" else host
 
 
+def _resolve_token(*env_vars: str) -> Optional[str]:
+    """First non-empty value among *env_vars*, canonical name first.
+
+    The LOGOS stack standardizes on ``SOPHIA_API_TOKEN`` / ``HERMES_API_TOKEN``;
+    the legacy ``*_API_KEY`` names are accepted as back-compat fallbacks so the
+    CLI authenticates with the same env the rest of the stack already sets.
+    """
+    for name in env_vars:
+        value = os.getenv(name)
+        if value:
+            return value
+    return None
+
+
 class SophiaConfig(BaseModel):
     """Configuration for Sophia cognitive core connection."""
 
@@ -46,8 +60,9 @@ class SophiaConfig(BaseModel):
     )
     timeout: int = Field(default=30, description="Request timeout in seconds")
     api_key: Optional[str] = Field(
-        default_factory=lambda: os.getenv("SOPHIA_API_KEY"),
-        description="Bearer token for Sophia API access",
+        default_factory=lambda: _resolve_token("SOPHIA_API_TOKEN", "SOPHIA_API_KEY"),
+        description="Bearer token for Sophia API access "
+        "(SOPHIA_API_TOKEN, or legacy SOPHIA_API_KEY)",
     )
 
 
@@ -67,8 +82,9 @@ class HermesConfig(BaseModel):
     )
     timeout: int = Field(default=30, description="Request timeout in seconds")
     api_key: Optional[str] = Field(
-        default_factory=lambda: os.getenv("HERMES_API_KEY"),
-        description="Bearer token for Hermes API access",
+        default_factory=lambda: _resolve_token("HERMES_API_TOKEN", "HERMES_API_KEY"),
+        description="Bearer token for Hermes API access "
+        "(HERMES_API_TOKEN, or legacy HERMES_API_KEY)",
     )
     provider: Optional[str] = Field(
         default=None, description="Preferred Hermes provider override"

--- a/src/apollo/data/hcg_client.py
+++ b/src/apollo/data/hcg_client.py
@@ -150,7 +150,9 @@ class HCGClient:
         """
         properties = dict(node)
         return Entity(
-            id=properties.get("id", str(node.id)),
+            # LOGOS nodes key on a stable `uuid`; fall back to a legacy `id`
+            # property, then the (unstable) internal node id as a last resort.
+            id=properties.get("id") or properties.get("uuid") or str(node.id),
             type=properties.get("type", "unknown"),
             properties=self._sanitize_props(properties),
             labels=list(node.labels),
@@ -628,6 +630,189 @@ class HCGClient:
                     "entity_types": entity_types or [],
                 },
             )
+
+    # ------------------------------------------------------------------
+    # Scoped / de-reified graph queries (CLI + explorer share this layer)
+    # ------------------------------------------------------------------
+    def get_graph_stats(self) -> Dict[str, Any]:
+        """Counts that let a client size the graph before fetching any of it.
+
+        Separates *content* nodes (the logical graph) from reified *edge-nodes*
+        (predicate/IS_A edges stored as nodes), so a UI/CLI can show real scale
+        (content) vs storage scale (all nodes) without loading the graph.
+        """
+        if not self._driver:
+            self.connect()
+        with self._driver.session() as session:  # type: ignore
+            totals = session.run(
+                """
+                MATCH (n)
+                RETURN count(n) AS total,
+                       count(CASE WHEN n.relation IS NULL THEN 1 END) AS content,
+                       count(CASE WHEN n.relation IS NOT NULL THEN 1 END) AS edges
+                """
+            ).single()
+            type_row = session.run(
+                "MATCH (n) WHERE n.type = 'type_definition' RETURN count(n) AS c"
+            ).single()
+            by_realm = {
+                r["realm"]: r["c"]
+                for r in session.run(
+                    "MATCH (n) WHERE n.relation IS NULL AND n.type IS NOT NULL "
+                    "RETURN n.type AS realm, count(n) AS c ORDER BY c DESC"
+                )
+            }
+            top_predicates = {
+                r["rel"]: r["c"]
+                for r in session.run(
+                    "MATCH (n) WHERE n.relation IS NOT NULL "
+                    "RETURN n.relation AS rel, count(n) AS c ORDER BY c DESC LIMIT 20"
+                )
+            }
+        return {
+            "total_nodes": totals["total"] if totals else 0,
+            "content_nodes": totals["content"] if totals else 0,
+            "edge_nodes": totals["edges"] if totals else 0,
+            "type_definitions": type_row["c"] if type_row else 0,
+            "by_realm": by_realm,
+            "top_predicates": top_predicates,
+        }
+
+    def get_type_summaries(self, limit: int = 500) -> List[Dict[str, Any]]:
+        """The positional type layer, computed server-side.
+
+        A type is *any node something IS_A's* (positional typing) — not a node
+        tagged ``type_definition`` — so emergent types are included. Each row
+        carries the type's member count (incoming IS_A) and its parent type.
+        """
+        if not self._driver:
+            self.connect()
+        query = """
+        MATCH (isa:Node {relation:'IS_A'})-[:TO]->(t)
+        WITH t, count(DISTINCT isa) AS member_count
+        OPTIONAL MATCH (t)<-[:FROM]-(pe:Node {relation:'IS_A'})-[:TO]->(parent)
+        RETURN t.uuid AS uuid, t.name AS name, member_count, parent.name AS parent
+        ORDER BY member_count DESC, name
+        LIMIT $limit
+        """
+        with self._driver.session() as session:  # type: ignore
+            return [
+                {
+                    "uuid": r["uuid"],
+                    "name": r["name"],
+                    "member_count": r["member_count"],
+                    "parent": r["parent"],
+                }
+                for r in session.run(query, limit=limit)
+            ]
+
+    def get_neighborhood(
+        self,
+        node_id: str,
+        depth: int = 1,
+        limit: int = 100,
+    ) -> GraphSnapshot:
+        """De-reified logical neighborhood of a node, scoped by depth + limit.
+
+        Collapses reified edge-nodes back to logical edges (src --predicate-->
+        tgt) and returns only content nodes, so a client can expand the graph one
+        neighborhood at a time instead of loading the whole thing. ``depth`` is
+        clamped to [1, 4]; expansion stops once ``limit`` nodes are collected.
+        """
+        node_id = validate_entity_id(node_id)
+        depth = max(1, min(depth, 4))
+        if not self._driver:
+            self.connect()
+
+        expand = """
+        UNWIND $roots AS rid
+        MATCH (root {uuid: rid})
+        MATCH (e)-[:FROM|TO]->(root) WHERE e.relation IS NOT NULL
+        MATCH (e)-[:FROM]->(src) MATCH (e)-[:TO]->(tgt)
+        RETURN DISTINCT e, src, tgt
+        """
+        entities: Dict[str, Entity] = {}
+        edges: Dict[str, CausalEdge] = {}
+        frontier: List[str] = [node_id]
+        seen_roots: set = set()
+
+        with self._driver.session() as session:  # type: ignore
+            root_rec = session.run(
+                "MATCH (root {uuid: $rid}) RETURN root LIMIT 1",
+                rid=node_id,
+            ).single()
+            if root_rec:
+                root = self._parse_node(root_rec["root"])
+                entities[root.id] = root
+
+            for _ in range(depth):
+                roots = [r for r in frontier if r not in seen_roots]
+                seen_roots.update(roots)
+                if not roots or len(entities) >= limit:
+                    break
+                next_frontier: List[str] = []
+                for rec in session.run(expand, roots=roots):
+                    src = self._parse_node(rec["src"])
+                    tgt = self._parse_node(rec["tgt"])
+                    props = dict(rec["e"])
+                    for node in (src, tgt):
+                        if node.id not in entities and len(entities) < limit:
+                            entities[node.id] = node
+                            next_frontier.append(node.id)
+                    edge_id = props.get("uuid", str(rec["e"].id))
+                    edges[edge_id] = CausalEdge(
+                        id=edge_id,
+                        source_id=src.id,
+                        target_id=tgt.id,
+                        edge_type=props.get("relation", "RELATED"),
+                        properties=self._sanitize_props(props),
+                        weight=props.get("weight", 1.0),
+                        created_at=self._convert_value(props.get("created_at"))
+                        or datetime.now(timezone.utc),
+                    )
+                frontier = next_frontier
+
+        node_ids = set(entities)
+        kept_edges = [
+            e
+            for e in edges.values()
+            if e.source_id in node_ids and e.target_id in node_ids
+        ]
+        return GraphSnapshot(
+            entities=list(entities.values()),
+            edges=kept_edges,
+            timestamp=datetime.now(timezone.utc),
+            metadata={
+                "root": node_id,
+                "depth": depth,
+                "entity_count": len(entities),
+                "edge_count": len(kept_edges),
+                "reified": False,
+            },
+        )
+
+    def search_nodes(self, query: str, limit: int = 25) -> List[Entity]:
+        """Find content nodes whose name contains *query* (or whose uuid equals
+        it) — entry points for navigating a large graph."""
+        if not self._driver:
+            self.connect()
+        q = (query or "").strip()
+        if not q:
+            return []
+        cypher = """
+        MATCH (n)
+        WHERE n.relation IS NULL
+          AND ((n.name IS NOT NULL AND toLower(n.name) CONTAINS toLower($q))
+               OR n.uuid = $q)
+        RETURN n
+        ORDER BY n.name
+        LIMIT $limit
+        """
+        with self._driver.session() as session:  # type: ignore
+            return [
+                self._parse_node(rec["n"])
+                for rec in session.run(cypher, q=q, limit=limit)
+            ]
 
     def health_check(self) -> bool:
         """Check if Neo4j connection is healthy.

--- a/src/apollo/data/hcg_client.py
+++ b/src/apollo/data/hcg_client.py
@@ -234,7 +234,7 @@ class HCGClient:
 
         query = """
         MATCH (n)
-        WHERE n.id = $entity_id OR id(n) = $node_id
+        WHERE n.id = $entity_id OR n.uuid = $entity_id OR id(n) = $node_id
         RETURN n
         """
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -30,6 +30,33 @@ def test_sophia_config_reads_env() -> None:
         assert config.port == 9999
 
 
+def test_sophia_config_reads_api_token() -> None:
+    """SophiaConfig reads the canonical SOPHIA_API_TOKEN env var."""
+    with patch.dict(os.environ, {"SOPHIA_API_TOKEN": "tok-123"}, clear=False):
+        os.environ.pop("SOPHIA_API_KEY", None)
+        assert SophiaConfig().api_key == "tok-123"
+
+
+def test_sophia_config_falls_back_to_api_key() -> None:
+    """SophiaConfig still honors the legacy SOPHIA_API_KEY var as a fallback."""
+    with patch.dict(os.environ, {"SOPHIA_API_KEY": "key-456"}, clear=False):
+        os.environ.pop("SOPHIA_API_TOKEN", None)
+        assert SophiaConfig().api_key == "key-456"
+
+
+def test_sophia_config_prefers_token_over_key() -> None:
+    """When both are set, the canonical SOPHIA_API_TOKEN wins."""
+    with patch.dict(os.environ, {"SOPHIA_API_TOKEN": "tok", "SOPHIA_API_KEY": "key"}):
+        assert SophiaConfig().api_key == "tok"
+
+
+def test_hermes_config_reads_api_token() -> None:
+    """HermesConfig reads the canonical HERMES_API_TOKEN env var."""
+    with patch.dict(os.environ, {"HERMES_API_TOKEN": "htok"}, clear=False):
+        os.environ.pop("HERMES_API_KEY", None)
+        assert HermesConfig().api_key == "htok"
+
+
 def test_neo4j_config_loads() -> None:
     """Test Neo4jConfig loads and has expected fields."""
     config = Neo4jConfig()

--- a/tests/unit/test_graph_parity.py
+++ b/tests/unit/test_graph_parity.py
@@ -1,0 +1,44 @@
+"""Parity: every scoped HCG graph capability is reachable from BOTH surfaces.
+
+The CLI (`apollo-cli graph ...`) and the API (`/api/hcg/...`) are thin presenters
+over the same ``HCGClient`` methods, so query *logic* can't drift. This guards the
+remaining risk -- *surface* drift: adding a capability to one presenter but not the
+other. Adding a scoped graph capability means adding a row to GRAPH_CAPABILITIES,
+which then forces both a CLI command and an API route to exist (Task #12).
+"""
+
+from apollo.data.hcg_client import HCGClient
+
+# scoped HCGClient method -> (CLI `graph` subcommand, API route prefix)
+GRAPH_CAPABILITIES = {
+    "get_graph_stats": ("stats", "/api/hcg/stats"),
+    "get_type_summaries": ("types", "/api/hcg/types"),
+    "get_neighborhood": ("neighbors", "/api/hcg/neighborhood"),
+    "search_nodes": ("search", "/api/hcg/search"),
+}
+
+
+def test_capabilities_exist_on_client() -> None:
+    """Each capability names a real HCGClient method (the shared source of truth)."""
+    for method in GRAPH_CAPABILITIES:
+        assert callable(getattr(HCGClient, method, None)), f"HCGClient.{method} missing"
+
+
+def test_cli_exposes_every_capability() -> None:
+    """Every capability has an `apollo-cli graph <cmd>` command."""
+    from apollo.cli.main import graph
+
+    commands = set(graph.commands)
+    for method, (command, _route) in GRAPH_CAPABILITIES.items():
+        assert command in commands, f"CLI 'graph {command}' missing for {method}"
+
+
+def test_api_exposes_every_capability() -> None:
+    """Every capability has a matching `/api/hcg/...` route."""
+    from apollo.api.server import app
+
+    paths = [getattr(route, "path", "") for route in app.routes]
+    for method, (_command, route) in GRAPH_CAPABILITIES.items():
+        assert any(
+            path.startswith(route) for path in paths
+        ), f"API route {route} missing for {method}"

--- a/tests/unit/test_hcg_client.py
+++ b/tests/unit/test_hcg_client.py
@@ -404,3 +404,118 @@ def test_get_causal_edges_by_entity(
         session.run.assert_called_once()
         call_kwargs = session.run.call_args[1]
         assert call_kwargs.get("entity_id") == "entity_1"
+
+
+# ---------------------------------------------------------------------------
+# Scoped / de-reified graph queries
+# ---------------------------------------------------------------------------
+def _mk_node(props: dict, labels=("Node",)) -> Mock:
+    """Neo4j-node-like mock supporting ``dict(node)`` (matches patterns above)."""
+    node = Mock()
+    node.labels = list(labels)
+    node.id = props.get("_id", 1)
+    node.__getitem__ = lambda self, key: props[key]
+    node.keys = lambda: props.keys()
+    return node
+
+
+def test_search_nodes_empty_query_short_circuits(
+    neo4j_config: Neo4jConfig, mock_driver: Mock
+) -> None:
+    """An empty/whitespace query returns [] without querying Neo4j."""
+    with patch("apollo.data.hcg_client.GraphDatabase") as mock_gd:
+        mock_gd.driver.return_value = mock_driver
+        session = Mock()
+        mock_driver.session.return_value.__enter__.return_value = session
+        client = HCGClient(neo4j_config)
+        assert client.search_nodes("   ") == []
+        session.run.assert_not_called()
+
+
+def test_get_type_summaries_shapes_rows(
+    neo4j_config: Neo4jConfig, mock_driver: Mock
+) -> None:
+    """Positional type rows are shaped to {uuid, name, member_count, parent}."""
+    with patch("apollo.data.hcg_client.GraphDatabase") as mock_gd:
+        mock_gd.driver.return_value = mock_driver
+        session = Mock()
+        mock_driver.session.return_value.__enter__.return_value = session
+        session.run.return_value = [
+            {"uuid": "t1", "name": "cell", "member_count": 49, "parent": "entity"},
+        ]
+        client = HCGClient(neo4j_config)
+        rows = client.get_type_summaries()
+        assert rows == [
+            {"uuid": "t1", "name": "cell", "member_count": 49, "parent": "entity"}
+        ]
+
+
+def test_get_graph_stats_separates_content_and_edge_nodes(
+    neo4j_config: Neo4jConfig, mock_driver: Mock
+) -> None:
+    """Stats report content vs reified edge-node counts distinctly."""
+    with patch("apollo.data.hcg_client.GraphDatabase") as mock_gd:
+        mock_gd.driver.return_value = mock_driver
+        session = Mock()
+        mock_driver.session.return_value.__enter__.return_value = session
+        totals = Mock()
+        totals.single.return_value = {"total": 3, "content": 2, "edges": 1}
+        types = Mock()
+        types.single.return_value = {"c": 1}
+        session.run.side_effect = [
+            totals,
+            types,
+            [{"realm": "entity", "c": 2}],
+            [{"rel": "IS_A", "c": 5}],
+        ]
+        client = HCGClient(neo4j_config)
+        stats = client.get_graph_stats()
+        assert stats["content_nodes"] == 2
+        assert stats["edge_nodes"] == 1
+        assert stats["type_definitions"] == 1
+        assert stats["by_realm"] == {"entity": 2}
+        assert stats["top_predicates"] == {"IS_A": 5}
+
+
+def test_get_neighborhood_returns_dereified_logical_edges(
+    neo4j_config: Neo4jConfig, mock_driver: Mock
+) -> None:
+    """An edge-node (relation/FROM/TO) collapses to one logical src->tgt edge."""
+    with patch("apollo.data.hcg_client.GraphDatabase") as mock_gd:
+        mock_gd.driver.return_value = mock_driver
+        session = Mock()
+        mock_driver.session.return_value.__enter__.return_value = session
+        root = _mk_node({"uuid": "root-1", "name": "Root", "type": "entity"})
+        src = _mk_node({"uuid": "root-1", "name": "Root", "type": "entity"})
+        tgt = _mk_node({"uuid": "tgt-2", "name": "Target", "type": "entity"})
+        edge = _mk_node({"uuid": "e-1", "relation": "PART_OF"})
+        first = Mock()
+        first.single.return_value = {"root": root}
+        session.run.side_effect = [first, [{"e": edge, "src": src, "tgt": tgt}]]
+        client = HCGClient(neo4j_config)
+        snap = client.get_neighborhood("root-1", depth=1)
+        assert snap.metadata["reified"] is False
+        assert len(snap.edges) == 1
+        e = snap.edges[0]
+        assert (e.source_id, e.edge_type, e.target_id) == (
+            "root-1",
+            "PART_OF",
+            "tgt-2",
+        )
+        assert {n.id for n in snap.entities} == {"root-1", "tgt-2"}
+
+
+def test_get_neighborhood_clamps_depth(
+    neo4j_config: Neo4jConfig, mock_driver: Mock
+) -> None:
+    """Depth is clamped so a request can't accidentally walk the whole graph."""
+    with patch("apollo.data.hcg_client.GraphDatabase") as mock_gd:
+        mock_gd.driver.return_value = mock_driver
+        session = Mock()
+        mock_driver.session.return_value.__enter__.return_value = session
+        root_lookup = Mock()
+        root_lookup.single.return_value = None
+        session.run.side_effect = [root_lookup, []]
+        client = HCGClient(neo4j_config)
+        snap = client.get_neighborhood("missing", depth=99)
+        assert snap.metadata["depth"] == 4


### PR DESCRIPTION
Phases 0–2 of #197 — the backend + CLI half. The React explorer lazy-load (Phase 3) is a follow-up PR.

## What
- **Phase 0 — CLI auth**: read the canonical `SOPHIA_API_TOKEN`/`HERMES_API_TOKEN` (legacy `*_API_KEY` still works). The SDK Bearer wiring was already correct; only the var name differed.
- **Phase 1 — shared scoped layer on `HCGClient`** (the API and CLI both build on it, so logic can't drift):
  - `get_graph_stats()` — content vs reified edge-node counts + by-realm + top predicates
  - `get_type_summaries()` — the **positional** type layer (any IS_A target) with member counts + parent
  - `get_neighborhood(node, depth, limit)` — **de-reified** logical neighborhood (`src --predicate--> tgt`), depth-bounded BFS
  - `search_nodes(query)` — entry points
  - fix `_parse_node`/`get_entity_by_id` to key on the stable `uuid` (nodes carry no `id`)
- **Phase 2 — presenters + parity**:
  - `apollo-cli graph {stats|types|search|node|neighbors}` (imports `HCGClient`, works with no API process running)
  - `GET /api/hcg/{stats,types,neighborhood/{id},search}` (asyncio.to_thread + OTel spans)
  - `test_graph_parity`: a canonical capability map forces every scoped method to be reachable from **both** surfaces — drift is a red build

## Why
The explorer loads the whole graph (`limit: 10000`); ~66% of nodes are reified edge-nodes. Server-side de-reification + scoping is a ~3x reduction (7009 → 2316 content) and lets a huge graph be explored one neighborhood at a time.

## Verification
All four methods + the CLI commands verified live against the 7009-node graph. mypy/ruff/black clean, 59 unit tests (incl. parity).

https://claude.ai/code/session_01YbGTE3BmHaRBNmJRZbF2oA