### PR TITLE
feat(apollo-cli): visual graph commands (ask sophia; trees/panels/bars + inline image)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -267,6 +267,99 @@ files = [
 ]
 
 [[package]]
+name = "contourpy"
+version = "1.3.3"
+description = "Python library for calculating contours of 2D quadrilateral grids"
+optional = true
+python-versions = ">=3.11"
+groups = ["main"]
+markers = "extra == \"graph-image\""
+files = [
+    {file = "contourpy-1.3.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:709a48ef9a690e1343202916450bc48b9e51c049b089c7f79a267b46cffcdaa1"},
+    {file = "contourpy-1.3.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:23416f38bfd74d5d28ab8429cc4d63fa67d5068bd711a85edb1c3fb0c3e2f381"},
+    {file = "contourpy-1.3.3-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:929ddf8c4c7f348e4c0a5a3a714b5c8542ffaa8c22954862a46ca1813b667ee7"},
+    {file = "contourpy-1.3.3-cp311-cp311-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9e999574eddae35f1312c2b4b717b7885d4edd6cb46700e04f7f02db454e67c1"},
+    {file = "contourpy-1.3.3-cp311-cp311-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0bf67e0e3f482cb69779dd3061b534eb35ac9b17f163d851e2a547d56dba0a3a"},
+    {file = "contourpy-1.3.3-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:51e79c1f7470158e838808d4a996fa9bac72c498e93d8ebe5119bc1e6becb0db"},
+    {file = "contourpy-1.3.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:598c3aaece21c503615fd59c92a3598b428b2f01bfb4b8ca9c4edeecc2438620"},
+    {file = "contourpy-1.3.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:322ab1c99b008dad206d406bb61d014cf0174df491ae9d9d0fac6a6fda4f977f"},
+    {file = "contourpy-1.3.3-cp311-cp311-win32.whl", hash = "sha256:fd907ae12cd483cd83e414b12941c632a969171bf90fc937d0c9f268a31cafff"},
+    {file = "contourpy-1.3.3-cp311-cp311-win_amd64.whl", hash = "sha256:3519428f6be58431c56581f1694ba8e50626f2dd550af225f82fb5f5814d2a42"},
+    {file = "contourpy-1.3.3-cp311-cp311-win_arm64.whl", hash = "sha256:15ff10bfada4bf92ec8b31c62bf7c1834c244019b4a33095a68000d7075df470"},
+    {file = "contourpy-1.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b08a32ea2f8e42cf1d4be3169a98dd4be32bafe4f22b6c4cb4ba810fa9e5d2cb"},
+    {file = "contourpy-1.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:556dba8fb6f5d8742f2923fe9457dbdd51e1049c4a43fd3986a0b14a1d815fc6"},
+    {file = "contourpy-1.3.3-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:92d9abc807cf7d0e047b95ca5d957cf4792fcd04e920ca70d48add15c1a90ea7"},
+    {file = "contourpy-1.3.3-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b2e8faa0ed68cb29af51edd8e24798bb661eac3bd9f65420c1887b6ca89987c8"},
+    {file = "contourpy-1.3.3-cp312-cp312-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:626d60935cf668e70a5ce6ff184fd713e9683fb458898e4249b63be9e28286ea"},
+    {file = "contourpy-1.3.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d00e655fcef08aba35ec9610536bfe90267d7ab5ba944f7032549c55a146da1"},
+    {file = "contourpy-1.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:451e71b5a7d597379ef572de31eeb909a87246974d960049a9848c3bc6c41bf7"},
+    {file = "contourpy-1.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:459c1f020cd59fcfe6650180678a9993932d80d44ccde1fa1868977438f0b411"},
+    {file = "contourpy-1.3.3-cp312-cp312-win32.whl", hash = "sha256:023b44101dfe49d7d53932be418477dba359649246075c996866106da069af69"},
+    {file = "contourpy-1.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:8153b8bfc11e1e4d75bcb0bff1db232f9e10b274e0929de9d608027e0d34ff8b"},
+    {file = "contourpy-1.3.3-cp312-cp312-win_arm64.whl", hash = "sha256:07ce5ed73ecdc4a03ffe3e1b3e3c1166db35ae7584be76f65dbbe28a7791b0cc"},
+    {file = "contourpy-1.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:177fb367556747a686509d6fef71d221a4b198a3905fe824430e5ea0fda54eb5"},
+    {file = "contourpy-1.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d002b6f00d73d69333dac9d0b8d5e84d9724ff9ef044fd63c5986e62b7c9e1b1"},
+    {file = "contourpy-1.3.3-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:348ac1f5d4f1d66d3322420f01d42e43122f43616e0f194fc1c9f5d830c5b286"},
+    {file = "contourpy-1.3.3-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:655456777ff65c2c548b7c454af9c6f33f16c8884f11083244b5819cc214f1b5"},
+    {file = "contourpy-1.3.3-cp313-cp313-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:644a6853d15b2512d67881586bd03f462c7ab755db95f16f14d7e238f2852c67"},
+    {file = "contourpy-1.3.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4debd64f124ca62069f313a9cb86656ff087786016d76927ae2cf37846b006c9"},
+    {file = "contourpy-1.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a15459b0f4615b00bbd1e91f1b9e19b7e63aea7483d03d804186f278c0af2659"},
+    {file = "contourpy-1.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ca0fdcd73925568ca027e0b17ab07aad764be4706d0a925b89227e447d9737b7"},
+    {file = "contourpy-1.3.3-cp313-cp313-win32.whl", hash = "sha256:b20c7c9a3bf701366556e1b1984ed2d0cedf999903c51311417cf5f591d8c78d"},
+    {file = "contourpy-1.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:1cadd8b8969f060ba45ed7c1b714fe69185812ab43bd6b86a9123fe8f99c3263"},
+    {file = "contourpy-1.3.3-cp313-cp313-win_arm64.whl", hash = "sha256:fd914713266421b7536de2bfa8181aa8c699432b6763a0ea64195ebe28bff6a9"},
+    {file = "contourpy-1.3.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:88df9880d507169449d434c293467418b9f6cbe82edd19284aa0409e7fdb933d"},
+    {file = "contourpy-1.3.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:d06bb1f751ba5d417047db62bca3c8fde202b8c11fb50742ab3ab962c81e8216"},
+    {file = "contourpy-1.3.3-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e4e6b05a45525357e382909a4c1600444e2a45b4795163d3b22669285591c1ae"},
+    {file = "contourpy-1.3.3-cp313-cp313t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ab3074b48c4e2cf1a960e6bbeb7f04566bf36b1861d5c9d4d8ac04b82e38ba20"},
+    {file = "contourpy-1.3.3-cp313-cp313t-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6c3d53c796f8647d6deb1abe867daeb66dcc8a97e8455efa729516b997b8ed99"},
+    {file = "contourpy-1.3.3-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:50ed930df7289ff2a8d7afeb9603f8289e5704755c7e5c3bbd929c90c817164b"},
+    {file = "contourpy-1.3.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:4feffb6537d64b84877da813a5c30f1422ea5739566abf0bd18065ac040e120a"},
+    {file = "contourpy-1.3.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2b7e9480ffe2b0cd2e787e4df64270e3a0440d9db8dc823312e2c940c167df7e"},
+    {file = "contourpy-1.3.3-cp313-cp313t-win32.whl", hash = "sha256:283edd842a01e3dcd435b1c5116798d661378d83d36d337b8dde1d16a5fc9ba3"},
+    {file = "contourpy-1.3.3-cp313-cp313t-win_amd64.whl", hash = "sha256:87acf5963fc2b34825e5b6b048f40e3635dd547f590b04d2ab317c2619ef7ae8"},
+    {file = "contourpy-1.3.3-cp313-cp313t-win_arm64.whl", hash = "sha256:3c30273eb2a55024ff31ba7d052dde990d7d8e5450f4bbb6e913558b3d6c2301"},
+    {file = "contourpy-1.3.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fde6c716d51c04b1c25d0b90364d0be954624a0ee9d60e23e850e8d48353d07a"},
+    {file = "contourpy-1.3.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:cbedb772ed74ff5be440fa8eee9bd49f64f6e3fc09436d9c7d8f1c287b121d77"},
+    {file = "contourpy-1.3.3-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:22e9b1bd7a9b1d652cd77388465dc358dafcd2e217d35552424aa4f996f524f5"},
+    {file = "contourpy-1.3.3-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a22738912262aa3e254e4f3cb079a95a67132fc5a063890e224393596902f5a4"},
+    {file = "contourpy-1.3.3-cp314-cp314-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:afe5a512f31ee6bd7d0dda52ec9864c984ca3d66664444f2d72e0dc4eb832e36"},
+    {file = "contourpy-1.3.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f64836de09927cba6f79dcd00fdd7d5329f3fccc633468507079c829ca4db4e3"},
+    {file = "contourpy-1.3.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1fd43c3be4c8e5fd6e4f2baeae35ae18176cf2e5cced681cca908addf1cdd53b"},
+    {file = "contourpy-1.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6afc576f7b33cf00996e5c1102dc2a8f7cc89e39c0b55df93a0b78c1bd992b36"},
+    {file = "contourpy-1.3.3-cp314-cp314-win32.whl", hash = "sha256:66c8a43a4f7b8df8b71ee1840e4211a3c8d93b214b213f590e18a1beca458f7d"},
+    {file = "contourpy-1.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:cf9022ef053f2694e31d630feaacb21ea24224be1c3ad0520b13d844274614fd"},
+    {file = "contourpy-1.3.3-cp314-cp314-win_arm64.whl", hash = "sha256:95b181891b4c71de4bb404c6621e7e2390745f887f2a026b2d99e92c17892339"},
+    {file = "contourpy-1.3.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:33c82d0138c0a062380332c861387650c82e4cf1747aaa6938b9b6516762e772"},
+    {file = "contourpy-1.3.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ea37e7b45949df430fe649e5de8351c423430046a2af20b1c1961cae3afcda77"},
+    {file = "contourpy-1.3.3-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d304906ecc71672e9c89e87c4675dc5c2645e1f4269a5063b99b0bb29f232d13"},
+    {file = "contourpy-1.3.3-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ca658cd1a680a5c9ea96dc61cdbae1e85c8f25849843aa799dfd3cb370ad4fbe"},
+    {file = "contourpy-1.3.3-cp314-cp314t-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ab2fd90904c503739a75b7c8c5c01160130ba67944a7b77bbf36ef8054576e7f"},
+    {file = "contourpy-1.3.3-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b7301b89040075c30e5768810bc96a8e8d78085b47d8be6e4c3f5a0b4ed478a0"},
+    {file = "contourpy-1.3.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2a2a8b627d5cc6b7c41a4beff6c5ad5eb848c88255fda4a8745f7e901b32d8e4"},
+    {file = "contourpy-1.3.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:fd6ec6be509c787f1caf6b247f0b1ca598bef13f4ddeaa126b7658215529ba0f"},
+    {file = "contourpy-1.3.3-cp314-cp314t-win32.whl", hash = "sha256:e74a9a0f5e3fff48fb5a7f2fd2b9b70a3fe014a67522f79b7cca4c0c7e43c9ae"},
+    {file = "contourpy-1.3.3-cp314-cp314t-win_amd64.whl", hash = "sha256:13b68d6a62db8eafaebb8039218921399baf6e47bf85006fd8529f2a08ef33fc"},
+    {file = "contourpy-1.3.3-cp314-cp314t-win_arm64.whl", hash = "sha256:b7448cb5a725bb1e35ce88771b86fba35ef418952474492cf7c764059933ff8b"},
+    {file = "contourpy-1.3.3-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:cd5dfcaeb10f7b7f9dc8941717c6c2ade08f587be2226222c12b25f0483ed497"},
+    {file = "contourpy-1.3.3-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:0c1fc238306b35f246d61a1d416a627348b5cf0648648a031e14bb8705fcdfe8"},
+    {file = "contourpy-1.3.3-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:70f9aad7de812d6541d29d2bbf8feb22ff7e1c299523db288004e3157ff4674e"},
+    {file = "contourpy-1.3.3-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5ed3657edf08512fc3fe81b510e35c2012fbd3081d2e26160f27ca28affec989"},
+    {file = "contourpy-1.3.3-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:3d1a3799d62d45c18bafd41c5fa05120b96a28079f2393af559b843d1a966a77"},
+    {file = "contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880"},
+]
+
+[package.dependencies]
+numpy = ">=1.25"
+
+[package.extras]
+bokeh = ["bokeh", "selenium"]
+docs = ["furo", "sphinx (>=7.2)", "sphinx-copybutton"]
+mypy = ["bokeh", "contourpy[bokeh,docs]", "docutils-stubs", "mypy (==1.17.0)", "types-Pillow"]
+test = ["Pillow", "contourpy[test-no-images]", "matplotlib"]
+test-no-images = ["pytest", "pytest-cov", "pytest-rerunfailures", "pytest-xdist", "wurlitzer"]
+
+[[package]]
 name = "coverage"
 version = "7.13.4"
 description = "Code coverage measurement for Python"
@@ -386,6 +479,23 @@ files = [
 toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
 
 [[package]]
+name = "cycler"
+version = "0.12.1"
+description = "Composable style cycles"
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "extra == \"graph-image\""
+files = [
+    {file = "cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30"},
+    {file = "cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c"},
+]
+
+[package.extras]
+docs = ["ipython", "matplotlib", "numpydoc", "sphinx"]
+tests = ["pytest", "pytest-cov", "pytest-xdist"]
+
+[[package]]
 name = "deprecated"
 version = "1.3.1"
 description = "Python @deprecated decorator to deprecate old python classes, functions or methods."
@@ -423,6 +533,80 @@ typing-extensions = ">=4.8.0"
 [package.extras]
 all = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.5)", "httpx (>=0.23.0)", "itsdangerous (>=1.1.0)", "jinja2 (>=3.1.5)", "orjson (>=3.2.1)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.18)", "pyyaml (>=5.3.1)", "ujson (>=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0)", "uvicorn[standard] (>=0.12.0)"]
 standard = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.5)", "httpx (>=0.23.0)", "jinja2 (>=3.1.5)", "python-multipart (>=0.0.18)", "uvicorn[standard] (>=0.12.0)"]
+
+[[package]]
+name = "fonttools"
+version = "4.63.0"
+description = "Tools to manipulate font files"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"graph-image\""
+files = [
+    {file = "fonttools-4.63.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e3297a6a4059b4acc3a1e9a8b04741f240a80044eef08ebd32e8b5bcdddce75b"},
+    {file = "fonttools-4.63.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b1cd75a03ad8cb5bc40c90bfde68c0c47de423aa19e5c0f362b43520645eea94"},
+    {file = "fonttools-4.63.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0425b277a59cff3d80ca42162a8de360f318438a2ac83570842a678d826d579"},
+    {file = "fonttools-4.63.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d7e5c9973aa04c95650c96e5f5ad865fbf42d62079163ecfab1e01cbc2504c22"},
+    {file = "fonttools-4.63.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cb014d58140a38135f16064c74c652ed57aa0b75cbf8bb59cac821f7edb5334e"},
+    {file = "fonttools-4.63.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:032038247a96c1690f9f31e377c389383c902531b085aa4e4dabd6f57f870e69"},
+    {file = "fonttools-4.63.0-cp310-cp310-win32.whl", hash = "sha256:a8b33a82979e0a6a34ff435cc81317be1f95ec1ebb7a3a2d1c8a6a54f02ae44e"},
+    {file = "fonttools-4.63.0-cp310-cp310-win_amd64.whl", hash = "sha256:0c18358a155d75034911c5ee397a5b44cd19dd325dbb8b35fb60bf421d6a72ac"},
+    {file = "fonttools-4.63.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:2b8ae05d9eacf6081414d759c0a352769ac28ce31280d6bb8e77b03f9e3c449f"},
+    {file = "fonttools-4.63.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:79cdc9f567aec74a72918fd060283911406750cbc9fd28c1316023deb6ce31a9"},
+    {file = "fonttools-4.63.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c14b4fd138c4bafcca294765c547914e1aa431ae1ca94ab99d8db08c958bd3b"},
+    {file = "fonttools-4.63.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76ac49f929aecaf82d83250b8347e099d7aecba0f4726c1d9b6df3b8bb5fe18"},
+    {file = "fonttools-4.63.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:dcf076a4474fe0d7367e5bbf5b052c7284fa1feca729c04176ce513521afd8a0"},
+    {file = "fonttools-4.63.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:7dd683fef0663e9f0f45cf541d788d24caa3ec9db50796b588e1757d8b3bc007"},
+    {file = "fonttools-4.63.0-cp311-cp311-win32.whl", hash = "sha256:afefc1ed0a59785a7fb06ea7e1678e849c193e1e387db783579bc7b3056fcfcb"},
+    {file = "fonttools-4.63.0-cp311-cp311-win_amd64.whl", hash = "sha256:063e08bd17bd5a90127a14123de0d6a952dbc847695fd98b63c043d58057f90c"},
+    {file = "fonttools-4.63.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:37dd23e621e3b0aef1baa70a303b80aaf38449632cfc8fd2a55fb285bbccfc02"},
+    {file = "fonttools-4.63.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a9faff9e0c1f76f9fd55899d2ce785832efebab37eb8ae13995853aef178bef0"},
+    {file = "fonttools-4.63.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef3048ef05dbb552b89817713d9cac912e00d0fde4a3105c00d29e52e10c89af"},
+    {file = "fonttools-4.63.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:58dc6bb86a78d782f00f9190ca02c119cf5bbe2807536e361e18d42019f877d8"},
+    {file = "fonttools-4.63.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ee08ebfa58f6e1aeff5697ab9582105bb620008c1caafb681e4c557e7483027b"},
+    {file = "fonttools-4.63.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:27fdc65af8da6f88b9c6121c47a464cbe359fcfff7ff6fc2d37a1f395d755b78"},
+    {file = "fonttools-4.63.0-cp312-cp312-win32.whl", hash = "sha256:af2fd1664d00a397d75f806985ddb36282091c2131a73a6485c23b4a34722263"},
+    {file = "fonttools-4.63.0-cp312-cp312-win_amd64.whl", hash = "sha256:59ac449f8cca9b4ffa08d2e7bbadad87ce710d69d1eda5c3c1ce579baa987272"},
+    {file = "fonttools-4.63.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:cd7e9857e5e63738b9d9fd707bc1f59c8b09e5177726d23664db393c59bb08bd"},
+    {file = "fonttools-4.63.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c2a2a42198b696a6f48fad91709afb55176e66a5e566131219dba372fb7f8c59"},
+    {file = "fonttools-4.63.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e874792a8212b44583ea02189d9e693906b2f78b261f372f95d6c563210ac1d"},
+    {file = "fonttools-4.63.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:22135da48a348785c5e2d5d2d9d6bec5ed44adacbaeb9db12d9493bf6c6bfa68"},
+    {file = "fonttools-4.63.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ccf41f2efdf56994d22d73bef4ced1052161958169428d06ba9724ea9e9a64be"},
+    {file = "fonttools-4.63.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9ced0bd02ac751dd6319b0da88aaef24414e3b0dbc32bb4f24944821a3741a27"},
+    {file = "fonttools-4.63.0-cp313-cp313-win32.whl", hash = "sha256:85be818f5506e8a7753153def2c9550178f0ecae6a47b5e0e8dbb23f7cc90380"},
+    {file = "fonttools-4.63.0-cp313-cp313-win_amd64.whl", hash = "sha256:ba04cb5891d4c0c21b6da95eda8d7b090021508a294fff33464fc7d241e0856b"},
+    {file = "fonttools-4.63.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fd1e3094f42d806d3d7c79162fc59e5910fcbe3a7360c385b8da969bc4493745"},
+    {file = "fonttools-4.63.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6e528da43bc3791085f8cb6141b1d13e459226790240340fcbb4625649238b03"},
+    {file = "fonttools-4.63.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b2248c5decb223562f7902ff6325077a073f608ee8e33e88ad88db734eb9f49"},
+    {file = "fonttools-4.63.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:308f957cdeaf8abe4e5f2f124902ef405448af92c90f80e302a3b771c2e6116b"},
+    {file = "fonttools-4.63.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:bf00f21eb5fb721dbaf73d1e9da6d02a1af7768f2ebcf9798be98beab8ba90f6"},
+    {file = "fonttools-4.63.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c1aaa4b9c75798400ac043ce04d74e7830376c85095a5a6ed7cba2f17a266bf4"},
+    {file = "fonttools-4.63.0-cp314-cp314-win32.whl", hash = "sha256:22693918177bd9ceabec4736d338045f357769416fc6b0b2508eefef75b08616"},
+    {file = "fonttools-4.63.0-cp314-cp314-win_amd64.whl", hash = "sha256:7d782fac32985914c351556f68ac0855391572bcd87de50e05970d3cd4c96fc5"},
+    {file = "fonttools-4.63.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:6db5140a60a5d731d21ec076745b40a310607731b0a565b50776393188649001"},
+    {file = "fonttools-4.63.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7d76edbff9014094dbf03bd2d074709dfa6ec7aba13d838c937a2b33d2d6a86e"},
+    {file = "fonttools-4.63.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0eac00b9118c3c2f87d272e45341871c5b3066baa3c86897fa634a7c3fb59096"},
+    {file = "fonttools-4.63.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:51394295f1a51de8b5f30bdb1e1b9a4231536c7064ef5c6e211eec19fa36036f"},
+    {file = "fonttools-4.63.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9e12f105d2b6342c559c298afb674006bb2893afc7102dcf8a1b55b0486b4e40"},
+    {file = "fonttools-4.63.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:796f27556dbe094c4824f75ca85267e4df776c79036c8441469a4df37038c196"},
+    {file = "fonttools-4.63.0-cp314-cp314t-win32.whl", hash = "sha256:948428a275741f0b64b113c955425a953314f4b9ab9997f73a72c83e68e569c8"},
+    {file = "fonttools-4.63.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6d4741eb179121cab9eea4cb2393d24492373a260d7945006358c08cfbf45419"},
+    {file = "fonttools-4.63.0-py3-none-any.whl", hash = "sha256:445af2eab030a16b9171ea8bdda7ebf7d96bda2df88ee182a464252f6e05e20d"},
+    {file = "fonttools-4.63.0.tar.gz", hash = "sha256:caeb583deeb5168e694b65cda8b4ee62abedfa66cf88488734466f2366b9c4e0"},
+]
+
+[package.extras]
+all = ["brotli (>=1.0.1) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=0.8.0) ; platform_python_implementation != \"CPython\"", "lxml (>=4.0)", "lz4 (>=1.7.4.2)", "matplotlib", "munkres ; platform_python_implementation == \"PyPy\"", "pycairo", "scipy ; platform_python_implementation != \"PyPy\"", "skia-pathops (>=0.5.0)", "sympy", "uharfbuzz (>=0.45.0)", "unicodedata2 (>=17.0.0) ; python_version <= \"3.14\"", "xattr ; sys_platform == \"darwin\"", "zopfli (>=0.1.4)"]
+graphite = ["lz4 (>=1.7.4.2)"]
+interpolatable = ["munkres ; platform_python_implementation == \"PyPy\"", "pycairo", "scipy ; platform_python_implementation != \"PyPy\""]
+lxml = ["lxml (>=4.0)"]
+pathops = ["skia-pathops (>=0.5.0)"]
+plot = ["matplotlib"]
+repacker = ["uharfbuzz (>=0.45.0)"]
+symfont = ["sympy"]
+type1 = ["xattr ; sys_platform == \"darwin\""]
+unicode = ["unicodedata2 (>=17.0.0) ; python_version <= \"3.14\""]
+woff = ["brotli (>=1.0.1) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=0.8.0) ; platform_python_implementation != \"CPython\"", "zopfli (>=0.1.4)"]
 
 [[package]]
 name = "googleapis-common-protos"
@@ -680,6 +864,134 @@ files = [
 ]
 
 [[package]]
+name = "kiwisolver"
+version = "1.5.0"
+description = "A fast implementation of the Cassowary constraint solver"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"graph-image\""
+files = [
+    {file = "kiwisolver-1.5.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:32cc0a5365239a6ea0c6ed461e8838d053b57e397443c0ca894dcc8e388d4374"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cc0b66c1eec9021353a4b4483afb12dfd50e3669ffbb9152d6842eb34c7e29fd"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:86e0287879f75621ae85197b0877ed2f8b7aa57b511c7331dce2eb6f4de7d476"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:62f59da443c4f4849f73a51a193b1d9d258dcad0c41bc4d1b8fb2bcc04bfeb22"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9190426b7aa26c5229501fa297b8d0653cfd3f5a36f7990c264e157cbf886b3b"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c8277104ded0a51e699c8c3aff63ce2c56d4ed5519a5f73e0fd7057f959a2b9e"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8f9baf6f0a6e7571c45c8863010b45e837c3ee1c2c77fcd6ef423be91b21fedb"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cff8e5383db4989311f99e814feeb90c4723eb4edca425b9d5d9c3fefcdd9537"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:ebae99ed6764f2b5771c522477b311be313e8841d2e0376db2b10922daebbba4"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:d5cd5189fc2b6a538b75ae45433140c4823463918f7b1617c31e68b085c0022c"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f42c23db5d1521218a3276bb08666dcb662896a0be7347cba864eca45ff64ede"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-win_amd64.whl", hash = "sha256:94eff26096eb5395136634622515b234ecb6c9979824c1f5004c6e3c3c85ccd2"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-win_arm64.whl", hash = "sha256:dd952e03bfbb096cfe2dd35cd9e00f269969b67536cb4370994afc20ff2d0875"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9eed0f7edbb274413b6ee781cca50541c8c0facd3d6fd289779e494340a2b85c"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3c4923e404d6bcd91b6779c009542e5647fef32e4a5d75e115e3bbac6f2335eb"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0df54df7e686afa55e6f21fb86195224a6d9beb71d637e8d7920c95cf0f89aac"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2517e24d7315eb51c10664cdb865195df38ab74456c677df67bb47f12d088a27"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff710414307fefa903e0d9bdf300972f892c23477829f49504e59834f4195398"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6176c1811d9d5a04fa391c490cc44f451e240697a16977f11c6f722efb9041db"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:50847dca5d197fcbd389c805aa1a1cf32f25d2e7273dc47ab181a517666b68cc"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:01808c6d15f4c3e8559595d6d1fe6411c68e4a3822b4b9972b44473b24f4e679"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:f1f9f4121ec58628c96baa3de1a55a4e3a333c5102c8e94b64e23bf7b2083309"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:b7d335370ae48a780c6e6a6bbfa97342f563744c39c35562f3f367665f5c1de2"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:800ee55980c18545af444d93fdd60c56b580db5cc54867d8cbf8a1dc0829938c"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:c438f6ca858697c9ab67eb28246c92508af972e114cac34e57a6d4ba17a3ac08"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:8c63c91f95173f9c2a67c7c526b2cea976828a0e7fced9cdcead2802dc10f8a4"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:beb7f344487cdcb9e1efe4b7a29681b74d34c08f0043a327a74da852a6749e7b"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-win_arm64.whl", hash = "sha256:ad4ae4ffd1ee9cd11357b4c66b612da9888f4f4daf2f36995eda64bd45370cac"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4e9750bc21b886308024f8a54ccb9a2cc38ac9fa813bf4348434e3d54f337ff9"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:72ec46b7eba5b395e0a7b63025490d3214c11013f4aacb4f5e8d6c3041829588"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ed3a984b31da7481b103f68776f7128a89ef26ed40f4dc41a2223cda7fb24819"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bb5136fb5352d3f422df33f0c879a1b0c204004324150cc3b5e3c4f310c9049f"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b2af221f268f5af85e776a73d62b0845fc8baf8ef0abfae79d29c77d0e776aaf"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b0f172dc8ffaccb8522d7c5d899de00133f2f1ca7b0a49b7da98e901de87bf2d"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6ab8ba9152203feec73758dad83af9a0bbe05001eb4639e547207c40cfb52083"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:cdee07c4d7f6d72008d3f73b9bf027f4e11550224c7c50d8df1ae4a37c1402a6"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7c60d3c9b06fb23bd9c6139281ccbdc384297579ae037f08ae90c69f6845c0b1"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:e315e5ec90d88e140f57696ff85b484ff68bb311e36f2c414aa4286293e6dee0"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:1465387ac63576c3e125e5337a6892b9e99e0627d52317f3ca79e6930d889d15"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:530a3fd64c87cffa844d4b6b9768774763d9caa299e9b75d8eca6a4423b31314"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1d9daea4ea6b9be74fe2f01f7fbade8d6ffab263e781274cffca0dba9be9eec9"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:f18c2d9782259a6dc132fdc7a63c168cbc74b35284b6d75c673958982a378384"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:f7c7553b13f69c1b29a5bde08ddc6d9d0c8bfb84f9ed01c30db25944aeb852a7"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:fd40bb9cd0891c4c3cb1ddf83f8bbfa15731a248fdc8162669405451e2724b09"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c0e1403fd7c26d77c1f03e096dc58a5c726503fa0db0456678b8668f76f521e3"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:dda366d548e89a90d88a86c692377d18d8bd64b39c1fb2b92cb31370e2896bbd"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:332b4f0145c30b5f5ad9374881133e5aa64320428a57c2c2b61e9d891a51c2f3"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c50b89ffd3e1a911c69a1dd3de7173c0cd10b130f56222e57898683841e4f96"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4db576bb8c3ef9365f8b40fe0f671644de6736ae2c27a2c62d7d8a1b4329f099"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0b85aad90cea8ac6797a53b5d5f2e967334fa4d1149f031c4537569972596cb8"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:d36ca54cb4c6c4686f7cbb7b817f66f5911c12ddb519450bbe86707155028f87"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:38f4a703656f493b0ad185211ccfca7f0386120f022066b018eb5296d8613e23"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:3ac2360e93cb41be81121755c6462cff3beaa9967188c866e5fce5cf13170859"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c95cab08d1965db3d84a121f1c7ce7479bdd4072c9b3dafd8fecce48a2e6b902"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:fc20894c3d21194d8041a28b65622d5b86db786da6e3cfe73f0c762951a61167"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7a32f72973f0f950c1920475d5c5ea3d971b81b6f0ec53b8d0a956cc965f22e0"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:0bf3acf1419fa93064a4c2189ac0b58e3be7872bf6ee6177b0d4c63dc4cea276"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:fa8eb9ecdb7efb0b226acec134e0d709e87a909fa4971a54c0c4f6e88635484c"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:db485b3847d182b908b483b2ed133c66d88d49cacf98fd278fadafe11b4478d1"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:be12f931839a3bdfe28b584db0e640a65a8bcbc24560ae3fdb025a449b3d754e"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:16b85d37c2cbb3253226d26e64663f755d88a03439a9c47df6246b35defbdfb7"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4432b835675f0ea7414aab3d37d119f7226d24869b7a829caeab49ebda407b0c"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b0feb50971481a2cc44d94e88bdb02cdd497618252ae226b8eb1201b957e368"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:56fa888f10d0f367155e76ce849fa1166fc9730d13bd2d65a2aa13b6f5424489"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:940dda65d5e764406b9fb92761cbf462e4e63f712ab60ed98f70552e496f3bf1"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-manylinux_2_39_riscv64.whl", hash = "sha256:89fc958c702ee9a745e4700378f5d23fddbc46ff89e8fdbf5395c24d5c1452a3"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9027d773c4ff81487181a925945743413f6069634d0b122d0b37684ccf4f1e18"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:5b233ea3e165e43e35dba1d2b8ecc21cf070b45b65ae17dd2747d2713d942021"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ce9bf03dad3b46408c08649c6fbd6ca28a9fce0eb32fdfffa6775a13103b5310"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:fc4d3f1fb9ca0ae9f97b095963bc6326f1dbfd3779d6679a1e016b9baaa153d3"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f443b4825c50a51ee68585522ab4a1d1257fac65896f282b4c6763337ac9f5d2"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-win_arm64.whl", hash = "sha256:893ff3a711d1b515ba9da14ee090519bad4610ed1962fbe298a434e8c5f8db53"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8df31fe574b8b3993cc61764f40941111b25c2d9fea13d3ce24a49907cd2d615"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1d49a49ac4cbfb7c1375301cd1ec90169dfeae55ff84710d782260ce77a75a02"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0cbe94b69b819209a62cb27bdfa5dc2a8977d8de2f89dfd97ba4f53ed3af754e"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:80aa065ffd378ff784822a6d7c3212f2d5f5e9c3589614b5c228b311fd3063ac"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e7f886f47ab881692f278ae901039a234e4025a68e6dfab514263a0b1c4ae05"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5060731cc3ed12ca3a8b57acd4aeca5bbc2f49216dd0bec1650a1acd89486bcd"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7a4aa69609f40fce3cbc3f87b2061f042eee32f94b8f11db707b66a26461591a"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:d168fda2dbff7b9b5f38e693182d792a938c31db4dac3a80a4888de603c99554"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:413b820229730d358efd838ecbab79902fe97094565fdc80ddb6b0a18c18a581"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:5124d1ea754509b09e53738ec185584cc609aae4a3b510aaf4ed6aa047ef9303"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e4415a8db000bf49a6dd1c478bf70062eaacff0f462b92b0ba68791a905861f9"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d618fd27420381a4f6044faa71f46d8bfd911bd077c555f7138ed88729bfbe79"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5092eb5b1172947f57d6ea7d89b2f29650414e4293c47707eb499ec07a0ac796"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:d76e2d8c75051d58177e762164d2e9ab92886534e3a12e795f103524f221dd8e"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:fa6248cd194edff41d7ea9425ced8ca3a6f838bfb295f6f1d6e6bb694a8518df"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:d1ffeb80b5676463d7a7d56acbe8e37a20ce725570e09549fe738e02ca6b7e1e"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:bc4d8e252f532ab46a1de9349e2d27b91fce46736a9eedaa37beaca66f574ed4"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6783e069732715ad0c3ce96dbf21dbc2235ab0593f2baf6338101f70371f4028"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e7c4c09a490dc4d4a7f8cbee56c606a320f9dc28cf92a7157a39d1ce7676a657"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2a075bd7bd19c70cf67c8badfa36cf7c5d8de3c9ddb8420c51e10d9c50e94920"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bdd3e53429ff02aa319ba59dfe4ceeec345bf46cf180ec2cf6fd5b942e7975e9"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3cdcb35dc9d807259c981a85531048ede628eabcffb3239adf3d17463518992d"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:70d593af6a6ca332d1df73d519fddb5148edb15cd90d5f0155e3746a6d4fcc65"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:377815a8616074cabbf3f53354e1d040c35815a134e01d7614b7692e4bf8acfa"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0255a027391d52944eae1dbb5d4cc5903f57092f3674e8e544cdd2622826b3f0"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:012b1eb16e28718fa782b5e61dc6f2da1f0792ca73bd05d54de6cb9561665fc9"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:0e3aafb33aed7479377e5e9a82e9d4bf87063741fc99fc7ae48b0f16e32bdd6f"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e7a116ae737f0000343218c4edf5bd45893bfeaff0993c0b215d7124c9f77646"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1dd9b0b119a350976a6d781e7278ec7aca0b201e1a9e2d23d9804afecb6ca681"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:58f812017cd2985c21fbffb4864d59174d4903dd66fa23815e74bbc7a0e2dd57"},
+    {file = "kiwisolver-1.5.0-graalpy312-graalpy250_312_native-macosx_10_13_x86_64.whl", hash = "sha256:5ae8e62c147495b01a0f4765c878e9bfdf843412446a247e28df59936e99e797"},
+    {file = "kiwisolver-1.5.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:f6764a4ccab3078db14a632420930f6186058750df066b8ea2a7106df91d3203"},
+    {file = "kiwisolver-1.5.0-graalpy312-graalpy250_312_native-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c31c13da98624f957b0fb1b5bae5383b2333c2c3f6793d9825dd5ce79b525cb7"},
+    {file = "kiwisolver-1.5.0-graalpy312-graalpy250_312_native-win_amd64.whl", hash = "sha256:1f1489f769582498610e015a8ef2d36f28f505ab3096d0e16b4858a9ec214f57"},
+    {file = "kiwisolver-1.5.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:295d9ffe712caa9f8a3081de8d32fc60191b4b51c76f02f951fd8407253528f4"},
+    {file = "kiwisolver-1.5.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:51e8c4084897de9f05898c2c2a39af6318044ae969d46ff7a34ed3f96274adca"},
+    {file = "kiwisolver-1.5.0-pp310-pypy310_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b83af57bdddef03c01a9138034c6ff03181a3028d9a1003b301eb1a55e161a3f"},
+    {file = "kiwisolver-1.5.0-pp310-pypy310_pp73-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bf4679a3d71012a7c2bf360e5cd878fbd5e4fcac0896b56393dec239d81529ed"},
+    {file = "kiwisolver-1.5.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:41024ed50e44ab1a60d3fe0a9d15a4ccc9f5f2b1d814ff283c8d01134d5b81bc"},
+    {file = "kiwisolver-1.5.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:ec4c85dc4b687c7f7f15f553ff26a98bfe8c58f5f7f0ac8905f0ba4c7be60232"},
+    {file = "kiwisolver-1.5.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:12e91c215a96e39f57989c8912ae761286ac5a9584d04030ceb3368a357f017a"},
+    {file = "kiwisolver-1.5.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:be4a51a55833dc29ab5d7503e7bcb3b3af3402d266018137127450005cdfe737"},
+    {file = "kiwisolver-1.5.0-pp311-pypy311_pp73-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:daae526907e262de627d8f70058a0f64acc9e2641c164c99c8f594b34a799a16"},
+    {file = "kiwisolver-1.5.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:59cd8683f575d96df5bb48f6add94afc055012c29e28124fcae2b63661b9efb1"},
+    {file = "kiwisolver-1.5.0.tar.gz", hash = "sha256:d4193f3d9dc3f6f79aaed0e5637f45d98850ebf01f7ca20e69457f3e8946b66a"},
+]
+
+[[package]]
 name = "librt"
 version = "0.8.0"
 description = "Mypyc runtime library"
@@ -879,6 +1191,74 @@ rtd = ["ipykernel", "jupyter_sphinx", "mdit-py-plugins (>=0.5.0)", "myst-parser"
 testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions", "requests"]
 
 [[package]]
+name = "matplotlib"
+version = "3.11.0"
+description = "Python plotting package"
+optional = true
+python-versions = ">=3.11"
+groups = ["main"]
+markers = "extra == \"graph-image\""
+files = [
+    {file = "matplotlib-3.11.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:f857524b442f0f36e641868ce2171aafa88cb0bc0644f4e1d8a5df9b32649fef"},
+    {file = "matplotlib-3.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:57baa92fdc82948ed716eae6d2579d4d6f40965cd8d2f416755b4a72580a3233"},
+    {file = "matplotlib-3.11.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:630eee0e67d35cce2019a0e670719f4816e3b86aff0fa72729f6c69786fceb45"},
+    {file = "matplotlib-3.11.0-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5106c444d0bf966eee2853548c03772af4ab7199118e086c62fbac8ccb07c055"},
+    {file = "matplotlib-3.11.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4d7aea652b58e686444079be3376ef546bffa1eee9b9bb9c472b9fcf6cf410d3"},
+    {file = "matplotlib-3.11.0-cp311-cp311-win_amd64.whl", hash = "sha256:70a5b3e9a5dab708c0f039709ae7c68d5b4d254e291ef76492cdba230c8bb5e4"},
+    {file = "matplotlib-3.11.0-cp311-cp311-win_arm64.whl", hash = "sha256:3d68266213e73823ac3be90615bab0cf31f88851e114cdb1dd25dacf3b01e1a7"},
+    {file = "matplotlib-3.11.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:06b5872e9cf11adc8f589ded3ce11bc3e1061ad498259664fabc1f6615beb918"},
+    {file = "matplotlib-3.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0515d495124be3124340e59f164d901ed4484e2246a5b74cfa483cac3b80bd97"},
+    {file = "matplotlib-3.11.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:be5f93a1d21981bfb802ded0d77a0caa92d4342a47d45754fac77e314a506344"},
+    {file = "matplotlib-3.11.0-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:41635d7909d19e52e924a521dde6d8f670b0f53ab1d0e8c331fa831554f681d1"},
+    {file = "matplotlib-3.11.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:94f5000f67ca9faa300863ea17f8bce9175cb67b88bec4bc7780502d53dd7c9e"},
+    {file = "matplotlib-3.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:ac6f1ef39f3d0f9e2463303013094992cdbe0f85f43bc54155bc472b2042768e"},
+    {file = "matplotlib-3.11.0-cp312-cp312-win_arm64.whl", hash = "sha256:9dd11fb612ce7bc60b1de5b4fc87ff959d22317b5de42aabf392f66f97af22eb"},
+    {file = "matplotlib-3.11.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6ce3b839b34ae1f430b4616893a2945a2999debaa7e94e7e29a2a8bbf286f7b5"},
+    {file = "matplotlib-3.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:373db8f91214e8ccaf35ac833cc1dd59dd961e148bbd55dd027141591dde1313"},
+    {file = "matplotlib-3.11.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:be152b7570324dc8d01574cc9474dd2d803237acf528bcbb5b211fa347461a09"},
+    {file = "matplotlib-3.11.0-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:126f256df600652d7e4b394cf3164ff75210a00038f287c95a012a6f58d0e83f"},
+    {file = "matplotlib-3.11.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:03acfeddf87b0dddb11b081ef7740ad445a3ca8bcb6b8e3011b08f2cf802b75c"},
+    {file = "matplotlib-3.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:ab3722f04f3ff34c23b5012c5873d2894174e06c3822fcdac3610965a5ac7d06"},
+    {file = "matplotlib-3.11.0-cp313-cp313-win_arm64.whl", hash = "sha256:c945824670fb8915b4ac879e5e61f3c58e0913022f70a0de4c082b17372f8771"},
+    {file = "matplotlib-3.11.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:3489c3dc487669b4a980bc3068f87856de7a1564248d3f6c629efb2a58b03f24"},
+    {file = "matplotlib-3.11.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:6a98f5476ce784a50ce09998f4ae1e6a9f25043cef8a480c98949902eda74620"},
+    {file = "matplotlib-3.11.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:565af866fd63e4bd3f987d580afe27c44c2552a3b3305f4ecbb85133601ea6f3"},
+    {file = "matplotlib-3.11.0-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e6b3e64dea5062c570f04358e2711859f3531b459f29516274fbad889079e4f3"},
+    {file = "matplotlib-3.11.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:942b37c5db1899610bd1543ce8e13e4ecff9a4633e7f63bb6aa9205d2644ebd1"},
+    {file = "matplotlib-3.11.0-cp313-cp313t-win_amd64.whl", hash = "sha256:c08e649a6313e1291e713623b97a38e5bb4aa580b2a100a94a3309bc6b9c8eb3"},
+    {file = "matplotlib-3.11.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2746cd2c113742ff6ce37a864c5ac5fd7aa644568f445e66166e457ac78e40e0"},
+    {file = "matplotlib-3.11.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3338e3e3de128cf50d0d2fb92a122815daf9c755bd882a474343c05f8fd7ec79"},
+    {file = "matplotlib-3.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:25c2e5455efd8d99f41fb79871a31feb7d301569642e332ec58d72cfe9282bc3"},
+    {file = "matplotlib-3.11.0-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d9695457a467ff86d23f35037a43deb6f1134dd6d3e2ac8ce1e2087cff09ffb9"},
+    {file = "matplotlib-3.11.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:19c16c61dea63b3582918503e6b294193961261d9daa806d4ae2151f1ad05430"},
+    {file = "matplotlib-3.11.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2d72ea8b7924f3cb955e61518d21e43b3df1e6c8a793b480a0c1214f185d30ba"},
+    {file = "matplotlib-3.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:1c02da0a629dfa9debf52725ea06866b74c1fb70a895bae05e4493d34074f9f2"},
+    {file = "matplotlib-3.11.0-cp314-cp314-win_arm64.whl", hash = "sha256:aa55d73b3117d4b07f959cd9eb6f69b375d8df3414139c479388e551aa5d999d"},
+    {file = "matplotlib-3.11.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:a9d8c6e7cd2f0ddf11d8d92e520dd1d9d2abb0cf6ac8831e338666c81e905847"},
+    {file = "matplotlib-3.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:be050fcf32f729eda99f7f75a80bf67612ce16ab9ac1c23a387dcaede95cb70e"},
+    {file = "matplotlib-3.11.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dfabef0230d0697aa0d717385194dd41162e00207a68bf4abf94c2bf4c27dca0"},
+    {file = "matplotlib-3.11.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1644db30e759199443493ac5e5caec24fdb775a8f6123021f85ba47c4133c3cb"},
+    {file = "matplotlib-3.11.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:15b0d160079cb10699a0e98b5989c70677b2df7cacdc62af67c30f2facec46d9"},
+    {file = "matplotlib-3.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:446307e6b04b57b1f1239e228a1ec2af0d589a1008cebc3dfa3f5441d095cfb6"},
+    {file = "matplotlib-3.11.0-cp314-cp314t-win_arm64.whl", hash = "sha256:652fb5696271d4c50f196d22a5ff4f8e4444c74f847423570d7dc0aa2bbd0159"},
+    {file = "matplotlib-3.11.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:81ae77077a1e16d37a5b61096ccb07c8d90a99b518fa8256b8f21578932f2f62"},
+    {file = "matplotlib-3.11.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ddef37840695f5eef65f9f070fe2d2f510f584c2156203f9f622a5b0584efffd"},
+    {file = "matplotlib-3.11.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cf662e5ac5707658cb931e19972c4bd99f7b4f8b7bf79d3c821d239fa6b71e64"},
+    {file = "matplotlib-3.11.0.tar.gz", hash = "sha256:68c0c7be01b30dcca3638934f7f591df73401235cbdbf0d1ab1c71e7db7f8b57"},
+]
+
+[package.dependencies]
+contourpy = ">=1.0.1"
+cycler = ">=0.10"
+fonttools = ">=4.22.0"
+kiwisolver = ">=1.3.1"
+numpy = ">=1.25"
+packaging = ">=20.0"
+pillow = ">=9"
+pyparsing = ">=3"
+python-dateutil = ">=2.7"
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 description = "Markdown URL utilities"
@@ -982,6 +1362,113 @@ pytz = "*"
 numpy = ["numpy (>=1.7.0,<3.0.0)"]
 pandas = ["numpy (>=1.7.0,<3.0.0)", "pandas (>=1.1.0,<3.0.0)"]
 pyarrow = ["pyarrow (>=1.0.0)"]
+
+[[package]]
+name = "networkx"
+version = "3.6"
+description = "Python package for creating and manipulating graphs and networks"
+optional = true
+python-versions = ">=3.11"
+groups = ["main"]
+markers = "extra == \"graph-image\""
+files = [
+    {file = "networkx-3.6-py3-none-any.whl", hash = "sha256:cdb395b105806062473d3be36458d8f1459a4e4b98e236a66c3a48996e07684f"},
+    {file = "networkx-3.6.tar.gz", hash = "sha256:285276002ad1f7f7da0f7b42f004bcba70d381e936559166363707fdad3d72ad"},
+]
+
+[package.extras]
+benchmarking = ["asv", "virtualenv"]
+default = ["matplotlib (>=3.8)", "numpy (>=1.25)", "pandas (>=2.0)", "scipy (>=1.11.2)"]
+developer = ["mypy (>=1.15)", "pre-commit (>=4.1)"]
+doc = ["intersphinx-registry", "myst-nb (>=1.1)", "numpydoc (>=1.8.0)", "pillow (>=10)", "pydata-sphinx-theme (>=0.16)", "sphinx (>=8.0)", "sphinx-gallery (>=0.18)", "texext (>=0.6.7)"]
+example = ["cairocffi (>=1.7)", "contextily (>=1.6)", "igraph (>=0.11)", "iplotx (>=0.9.0)", "momepy (>=0.7.2)", "osmnx (>=2.0.0)", "scikit-learn (>=1.5)", "seaborn (>=0.13)"]
+extra = ["lxml (>=4.6)", "pydot (>=3.0.1)", "pygraphviz (>=1.14)", "sympy (>=1.10)"]
+release = ["build (>=0.10)", "changelist (==0.5)", "twine (>=4.0)", "wheel (>=0.40)"]
+test = ["pytest (>=7.2)", "pytest-cov (>=4.0)", "pytest-xdist (>=3.0)"]
+test-extras = ["pytest-mpl", "pytest-randomly"]
+
+[[package]]
+name = "numpy"
+version = "2.4.6"
+description = "Fundamental package for array computing in Python"
+optional = true
+python-versions = ">=3.11"
+groups = ["main"]
+markers = "extra == \"graph-image\""
+files = [
+    {file = "numpy-2.4.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0280e0356c0829a18d9de1cb7eee50ec22ca639878d7240307ca0943d73cd2c4"},
+    {file = "numpy-2.4.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:110f8b71aacb688ec69062bb7f6938a0f8acb01b7c1c4beb453c65b6d234584d"},
+    {file = "numpy-2.4.6-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:4cfe66903cc32a9921a6733d96b19bb6abf310397581bbad89c228f5abaf0ee8"},
+    {file = "numpy-2.4.6-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:8155154c7c691289fe18f510b5d4657c68c67989f293f0535a91360392ff6538"},
+    {file = "numpy-2.4.6-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ab0a9c4ffb1a6d95ef519fe4247dba8eb6b18ad93999f76b7f657039acabd47"},
+    {file = "numpy-2.4.6-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:89cd468399cfd2504718f0ba50e410dca55a170b61a02ad92bb18c8a65186e93"},
+    {file = "numpy-2.4.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c2d37ab77531417474168eb79d6d80b14f821a966818505d03013d0833edb7a8"},
+    {file = "numpy-2.4.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f407cb6b8e9d6d8c626bc73c945db1706035af8fd632295547bf1c9e46d092d6"},
+    {file = "numpy-2.4.6-cp311-cp311-win32.whl", hash = "sha256:ddea102b48f9e339f3948bf22040944184627a30fdf7f858667673b9c5f033c8"},
+    {file = "numpy-2.4.6-cp311-cp311-win_amd64.whl", hash = "sha256:1e254a00cdf42b1e4d5b3d68d33af63268d41340d8885df2ab6470f2e1500147"},
+    {file = "numpy-2.4.6-cp311-cp311-win_arm64.whl", hash = "sha256:ed9749eef4cbd126da3dc1d6bcb3a57f5eb7ac6a6484146bdbf743f552dfc577"},
+    {file = "numpy-2.4.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:001fbb8e08d942dd57599e781f2472269ee7f2755fae407b4f67b2f0b17da3f1"},
+    {file = "numpy-2.4.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ebfb099f8dcf083deef3ac1ca4c1503f387cf76296fcb3816b66f5ecb5f54fdb"},
+    {file = "numpy-2.4.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3213d622a0283a39a93d188f3cf72b26862df52fbb4ca3697f51705016523d41"},
+    {file = "numpy-2.4.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:357cc07a6d7b0b182ff02249616a03742827ebb1277546b5c7cd7f7620a45698"},
+    {file = "numpy-2.4.6-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f9fb9157b4ce2971008323afe46053787b526ef624fea915b261468a8421a0f"},
+    {file = "numpy-2.4.6-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90f9849678c75fe7afa2d348ac842c168b0a4d3d61919687216dfc547976d853"},
+    {file = "numpy-2.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c1a2af6c6ef86344a6b0db6b97834208bf598db514f2b155042439b62605601a"},
+    {file = "numpy-2.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5805d5a22fd19c8ccff10a9561f9df94436b0545619ea579db2d3c35294bce2"},
+    {file = "numpy-2.4.6-cp312-cp312-win32.whl", hash = "sha256:e3eeb0aabd6bd5ce64faae67e9935203a6991b4bc2a485a767fbafb2c5125f45"},
+    {file = "numpy-2.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:d8e8286dd7cea7895157318d1b91cdacac64c479f3cbc8dce548331728484751"},
+    {file = "numpy-2.4.6-cp312-cp312-win_arm64.whl", hash = "sha256:4081eb135ac24158bd51cdfbef16f1c64df7063b1143f24731387137c092bec8"},
+    {file = "numpy-2.4.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:511dbaf848decaaaf4b4ca48032619fb3138710c4bf7da7617765edad1ef96b0"},
+    {file = "numpy-2.4.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bf162abab1c1a736333192707cef898e735a5ca00f38f27eeedf44b39d9e85eb"},
+    {file = "numpy-2.4.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:043191bfa8eab18c776647b62723ac9dddece59743b13f49b2016094129c2b3f"},
+    {file = "numpy-2.4.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:6180d8b35af935aed8ece3a85e0a43f87393ae0ac87c8d2c8bd2c993f7270ef3"},
+    {file = "numpy-2.4.6-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72fbe16c6fac95aedf5937fa873445cec2110be35d8a4e9433d7501fd98dae6b"},
+    {file = "numpy-2.4.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7830bab239b79cda9c08c2da014761cafb48da6150e1da17ac06283f43b6089"},
+    {file = "numpy-2.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ef4aea96ce4d3b074422cb4f2f64e216bf9e213004bb58ecfdf50ea02ea8eb9a"},
+    {file = "numpy-2.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dfa20cc6ca228e6b155b11da03825975ce66aea520985dbbddf0f2a5a495c605"},
+    {file = "numpy-2.4.6-cp313-cp313-win32.whl", hash = "sha256:56b39e5e0622a09a25bf5baf62f4bcf0cb8a41ae6e2819cf49bbc5a74c083f91"},
+    {file = "numpy-2.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:c4fc99836233ea196540b17ab0983aff60ed07941751930f5f4d05bc3b3b7359"},
+    {file = "numpy-2.4.6-cp313-cp313-win_arm64.whl", hash = "sha256:a7c711e21628b52034bb5ab8d1bce291f752fcc5e92accc615778acee1ff4778"},
+    {file = "numpy-2.4.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:112b06a867b235ef466ed3508ddf0238050df9c727cafb5301ac385b899189a1"},
+    {file = "numpy-2.4.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:eaf7fa2de5c0be8ae6ff8e9bea2ccd725e980541244521d8d4b5f3354a27babe"},
+    {file = "numpy-2.4.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:7265a2f3d436e54ef9f2b52b5c937e6be778781bd97a590319d7348f1c1ca997"},
+    {file = "numpy-2.4.6-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f74a575920ab21fe304421a3fc28793d82e299cae9eccb37084e9fc7f3617c20"},
+    {file = "numpy-2.4.6-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ede83e07a75dd06bc501566c1eca2afc0d61677c1472ac9ad93fdee6e638a48d"},
+    {file = "numpy-2.4.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:68bb27509ac1b9a3443094260f6326150663b06abe40b73a2f81160623da5b67"},
+    {file = "numpy-2.4.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a0df0043bdb289bde1f62da130d20df23d58b45429f752bc7a8fc5325a225ecd"},
+    {file = "numpy-2.4.6-cp313-cp313t-win32.whl", hash = "sha256:29a287e0cf63ff528da061de6b9f64a4618da591ca1046aafc54062e40ca7eab"},
+    {file = "numpy-2.4.6-cp313-cp313t-win_amd64.whl", hash = "sha256:25c692919ac5a01f170a3bfcd62d745b24fd095c353d50812637d6fcab442e75"},
+    {file = "numpy-2.4.6-cp313-cp313t-win_arm64.whl", hash = "sha256:1e978ec1e8bd0e0e4de6bb75de9d30cbb74db6b6a2bb727618613703ca0167dd"},
+    {file = "numpy-2.4.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06ca2f61ec4385a07a6977c55ba998a4466c123642b4a32694d3128fce18c079"},
+    {file = "numpy-2.4.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:38efbc8de75c7a0fc1ac190162d892787f3f47b57cc291231aafee36b80982b7"},
+    {file = "numpy-2.4.6-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d581b735e177fdcdce6fed8e7e8880a3fb6ee4e3653a3ac6af01c6f4c03effc5"},
+    {file = "numpy-2.4.6-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:0a041d3d761dc3c35cc56ce0351506a02bcbc25f7b169f652435141a17db9096"},
+    {file = "numpy-2.4.6-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40fdc1ae7125e518ea98e53e69a4ebc27e1fd50510c47b7ea130cf21e5e1d42b"},
+    {file = "numpy-2.4.6-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2c306dea656c12c68f51f4cea133cbe78ca7435eb28c735eac1d3ebe73be6e8"},
+    {file = "numpy-2.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:33111801a01c12a8a1e3721f0a9232f8cfc8ae2c6b7098167e6f623c6073f402"},
+    {file = "numpy-2.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ae506e6902902557576a26ff33eda8695e7ecb3cb36c3b573a0765dee114ebdb"},
+    {file = "numpy-2.4.6-cp314-cp314-win32.whl", hash = "sha256:aaf159caa35993cb1f56fb9b8e4610d35758e7ca005412eb1daa856a78c9c4b1"},
+    {file = "numpy-2.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:b507f5c4c1d508876d1819b6bf9a49d365b96320b5d4993426b33a23ca4b8261"},
+    {file = "numpy-2.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:6f41ae150c4e32db4f3310cdaf64b1593a03dbabe29eec77fc9b50fe64061df6"},
+    {file = "numpy-2.4.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ece3d2cfe132e7d51f44a832b303895e6f2d499c5e74dfbdb06ee246147a304a"},
+    {file = "numpy-2.4.6-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:e3e5193ef5a3dc73bceee50f7fdc2c90dbb76c42df8d8fae3d1067a583df579e"},
+    {file = "numpy-2.4.6-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:17f9ade344e7d9b464a084d69bcf18fc691cb1db67c62ed80820bf4926d78f0e"},
+    {file = "numpy-2.4.6-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cd5ffd25db4e7ba6a375693b3fc0fc1791ec636c17db3720da19bde7180ec43"},
+    {file = "numpy-2.4.6-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d92c3819208a60205a12a245c91ad70cb0a85336659b19b834205573ac8456e"},
+    {file = "numpy-2.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e85b752a1e912b70eaad4fafbd4d1238007ab221de2009b9a2f5ae7461239895"},
+    {file = "numpy-2.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:29cb7f67d10b479ff07c17d33e39f78c07f71c40ef30d63c153d340e96cd3fb4"},
+    {file = "numpy-2.4.6-cp314-cp314t-win32.whl", hash = "sha256:260a5d70215b61ab4fadf5c7baacd64821842975eea312125ed3c39a6391b063"},
+    {file = "numpy-2.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:81a1cca95ed5bb92aa8b10dd2cdc9a0d3853a50fad926c28b5d7e8ea54389627"},
+    {file = "numpy-2.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:0c9136e14ed34a9e343a31c533d78a9813a69a3148332bce5e9821cb2f996e66"},
+    {file = "numpy-2.4.6-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:55cced7c52e981362f708ad635198e97a752dfba412cc03c23bbf3bd8d5cd662"},
+    {file = "numpy-2.4.6-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:d6da64deb6b8ed903e7560180a92f2d804ee1ba5eeb849ac2748b8c1aba1f6d7"},
+    {file = "numpy-2.4.6-pp311-pypy311_pp73-macosx_14_0_arm64.whl", hash = "sha256:68a5124b13fa6cc2086764a20005d30bc0548146f7f5322f02fce212ca14317f"},
+    {file = "numpy-2.4.6-pp311-pypy311_pp73-macosx_14_0_x86_64.whl", hash = "sha256:948424b06129ce883307e8cff868c31396d8dc7630a59c61d70d98dbe70f222c"},
+    {file = "numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5dbbdb29840ca3d91ee0fece42fc29278886d908280bfec0a5846c6f901a3eb0"},
+    {file = "numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ad03c0965fb3c692200e74d458ca28c1dbb4ce96f9a479a8aa041ad5fabca02"},
+    {file = "numpy-2.4.6-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:2803abfebfc990042cd494d8ce2d5f82e9d847af6d35ec486923aa19dbad5e73"},
+    {file = "numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda"},
+]
 
 [[package]]
 name = "opentelemetry-api"
@@ -1229,11 +1716,12 @@ version = "26.0"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529"},
     {file = "packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4"},
 ]
+markers = {main = "extra == \"graph-image\""}
 
 [[package]]
 name = "pathspec"
@@ -1252,6 +1740,105 @@ hyperscan = ["hyperscan (>=0.7)"]
 optional = ["typing-extensions (>=4)"]
 re2 = ["google-re2 (>=1.1)"]
 tests = ["pytest (>=9)", "typing-extensions (>=4.15)"]
+
+[[package]]
+name = "pillow"
+version = "10.4.0"
+description = "Python Imaging Library (Fork)"
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "extra == \"graph-image\""
+files = [
+    {file = "pillow-10.4.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:4d9667937cfa347525b319ae34375c37b9ee6b525440f3ef48542fcf66f2731e"},
+    {file = "pillow-10.4.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:543f3dc61c18dafb755773efc89aae60d06b6596a63914107f75459cf984164d"},
+    {file = "pillow-10.4.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7928ecbf1ece13956b95d9cbcfc77137652b02763ba384d9ab508099a2eca856"},
+    {file = "pillow-10.4.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e4d49b85c4348ea0b31ea63bc75a9f3857869174e2bf17e7aba02945cd218e6f"},
+    {file = "pillow-10.4.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:6c762a5b0997f5659a5ef2266abc1d8851ad7749ad9a6a5506eb23d314e4f46b"},
+    {file = "pillow-10.4.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:a985e028fc183bf12a77a8bbf36318db4238a3ded7fa9df1b9a133f1cb79f8fc"},
+    {file = "pillow-10.4.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:812f7342b0eee081eaec84d91423d1b4650bb9828eb53d8511bcef8ce5aecf1e"},
+    {file = "pillow-10.4.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:ac1452d2fbe4978c2eec89fb5a23b8387aba707ac72810d9490118817d9c0b46"},
+    {file = "pillow-10.4.0-cp310-cp310-win32.whl", hash = "sha256:bcd5e41a859bf2e84fdc42f4edb7d9aba0a13d29a2abadccafad99de3feff984"},
+    {file = "pillow-10.4.0-cp310-cp310-win_amd64.whl", hash = "sha256:ecd85a8d3e79cd7158dec1c9e5808e821feea088e2f69a974db5edf84dc53141"},
+    {file = "pillow-10.4.0-cp310-cp310-win_arm64.whl", hash = "sha256:ff337c552345e95702c5fde3158acb0625111017d0e5f24bf3acdb9cc16b90d1"},
+    {file = "pillow-10.4.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:0a9ec697746f268507404647e531e92889890a087e03681a3606d9b920fbee3c"},
+    {file = "pillow-10.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dfe91cb65544a1321e631e696759491ae04a2ea11d36715eca01ce07284738be"},
+    {file = "pillow-10.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5dc6761a6efc781e6a1544206f22c80c3af4c8cf461206d46a1e6006e4429ff3"},
+    {file = "pillow-10.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5e84b6cc6a4a3d76c153a6b19270b3526a5a8ed6b09501d3af891daa2a9de7d6"},
+    {file = "pillow-10.4.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:bbc527b519bd3aa9d7f429d152fea69f9ad37c95f0b02aebddff592688998abe"},
+    {file = "pillow-10.4.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:76a911dfe51a36041f2e756b00f96ed84677cdeb75d25c767f296c1c1eda1319"},
+    {file = "pillow-10.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:59291fb29317122398786c2d44427bbd1a6d7ff54017075b22be9d21aa59bd8d"},
+    {file = "pillow-10.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:416d3a5d0e8cfe4f27f574362435bc9bae57f679a7158e0096ad2beb427b8696"},
+    {file = "pillow-10.4.0-cp311-cp311-win32.whl", hash = "sha256:7086cc1d5eebb91ad24ded9f58bec6c688e9f0ed7eb3dbbf1e4800280a896496"},
+    {file = "pillow-10.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:cbed61494057c0f83b83eb3a310f0bf774b09513307c434d4366ed64f4128a91"},
+    {file = "pillow-10.4.0-cp311-cp311-win_arm64.whl", hash = "sha256:f5f0c3e969c8f12dd2bb7e0b15d5c468b51e5017e01e2e867335c81903046a22"},
+    {file = "pillow-10.4.0-cp312-cp312-macosx_10_10_x86_64.whl", hash = "sha256:673655af3eadf4df6b5457033f086e90299fdd7a47983a13827acf7459c15d94"},
+    {file = "pillow-10.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:866b6942a92f56300012f5fbac71f2d610312ee65e22f1aa2609e491284e5597"},
+    {file = "pillow-10.4.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29dbdc4207642ea6aad70fbde1a9338753d33fb23ed6956e706936706f52dd80"},
+    {file = "pillow-10.4.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bf2342ac639c4cf38799a44950bbc2dfcb685f052b9e262f446482afaf4bffca"},
+    {file = "pillow-10.4.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:f5b92f4d70791b4a67157321c4e8225d60b119c5cc9aee8ecf153aace4aad4ef"},
+    {file = "pillow-10.4.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:86dcb5a1eb778d8b25659d5e4341269e8590ad6b4e8b44d9f4b07f8d136c414a"},
+    {file = "pillow-10.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:780c072c2e11c9b2c7ca37f9a2ee8ba66f44367ac3e5c7832afcfe5104fd6d1b"},
+    {file = "pillow-10.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:37fb69d905be665f68f28a8bba3c6d3223c8efe1edf14cc4cfa06c241f8c81d9"},
+    {file = "pillow-10.4.0-cp312-cp312-win32.whl", hash = "sha256:7dfecdbad5c301d7b5bde160150b4db4c659cee2b69589705b6f8a0c509d9f42"},
+    {file = "pillow-10.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:1d846aea995ad352d4bdcc847535bd56e0fd88d36829d2c90be880ef1ee4668a"},
+    {file = "pillow-10.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:e553cad5179a66ba15bb18b353a19020e73a7921296a7979c4a2b7f6a5cd57f9"},
+    {file = "pillow-10.4.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8bc1a764ed8c957a2e9cacf97c8b2b053b70307cf2996aafd70e91a082e70df3"},
+    {file = "pillow-10.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6209bb41dc692ddfee4942517c19ee81b86c864b626dbfca272ec0f7cff5d9fb"},
+    {file = "pillow-10.4.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bee197b30783295d2eb680b311af15a20a8b24024a19c3a26431ff83eb8d1f70"},
+    {file = "pillow-10.4.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1ef61f5dd14c300786318482456481463b9d6b91ebe5ef12f405afbba77ed0be"},
+    {file = "pillow-10.4.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:297e388da6e248c98bc4a02e018966af0c5f92dfacf5a5ca22fa01cb3179bca0"},
+    {file = "pillow-10.4.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:e4db64794ccdf6cb83a59d73405f63adbe2a1887012e308828596100a0b2f6cc"},
+    {file = "pillow-10.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bd2880a07482090a3bcb01f4265f1936a903d70bc740bfcb1fd4e8a2ffe5cf5a"},
+    {file = "pillow-10.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4b35b21b819ac1dbd1233317adeecd63495f6babf21b7b2512d244ff6c6ce309"},
+    {file = "pillow-10.4.0-cp313-cp313-win32.whl", hash = "sha256:551d3fd6e9dc15e4c1eb6fc4ba2b39c0c7933fa113b220057a34f4bb3268a060"},
+    {file = "pillow-10.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:030abdbe43ee02e0de642aee345efa443740aa4d828bfe8e2eb11922ea6a21ea"},
+    {file = "pillow-10.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:5b001114dd152cfd6b23befeb28d7aee43553e2402c9f159807bf55f33af8a8d"},
+    {file = "pillow-10.4.0-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:8d4d5063501b6dd4024b8ac2f04962d661222d120381272deea52e3fc52d3736"},
+    {file = "pillow-10.4.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:7c1ee6f42250df403c5f103cbd2768a28fe1a0ea1f0f03fe151c8741e1469c8b"},
+    {file = "pillow-10.4.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b15e02e9bb4c21e39876698abf233c8c579127986f8207200bc8a8f6bb27acf2"},
+    {file = "pillow-10.4.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a8d4bade9952ea9a77d0c3e49cbd8b2890a399422258a77f357b9cc9be8d680"},
+    {file = "pillow-10.4.0-cp38-cp38-manylinux_2_28_aarch64.whl", hash = "sha256:43efea75eb06b95d1631cb784aa40156177bf9dd5b4b03ff38979e048258bc6b"},
+    {file = "pillow-10.4.0-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:950be4d8ba92aca4b2bb0741285a46bfae3ca699ef913ec8416c1b78eadd64cd"},
+    {file = "pillow-10.4.0-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:d7480af14364494365e89d6fddc510a13e5a2c3584cb19ef65415ca57252fb84"},
+    {file = "pillow-10.4.0-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:73664fe514b34c8f02452ffb73b7a92c6774e39a647087f83d67f010eb9a0cf0"},
+    {file = "pillow-10.4.0-cp38-cp38-win32.whl", hash = "sha256:e88d5e6ad0d026fba7bdab8c3f225a69f063f116462c49892b0149e21b6c0a0e"},
+    {file = "pillow-10.4.0-cp38-cp38-win_amd64.whl", hash = "sha256:5161eef006d335e46895297f642341111945e2c1c899eb406882a6c61a4357ab"},
+    {file = "pillow-10.4.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:0ae24a547e8b711ccaaf99c9ae3cd975470e1a30caa80a6aaee9a2f19c05701d"},
+    {file = "pillow-10.4.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:298478fe4f77a4408895605f3482b6cc6222c018b2ce565c2b6b9c354ac3229b"},
+    {file = "pillow-10.4.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:134ace6dc392116566980ee7436477d844520a26a4b1bd4053f6f47d096997fd"},
+    {file = "pillow-10.4.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:930044bb7679ab003b14023138b50181899da3f25de50e9dbee23b61b4de2126"},
+    {file = "pillow-10.4.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:c76e5786951e72ed3686e122d14c5d7012f16c8303a674d18cdcd6d89557fc5b"},
+    {file = "pillow-10.4.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:b2724fdb354a868ddf9a880cb84d102da914e99119211ef7ecbdc613b8c96b3c"},
+    {file = "pillow-10.4.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:dbc6ae66518ab3c5847659e9988c3b60dc94ffb48ef9168656e0019a93dbf8a1"},
+    {file = "pillow-10.4.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:06b2f7898047ae93fad74467ec3d28fe84f7831370e3c258afa533f81ef7f3df"},
+    {file = "pillow-10.4.0-cp39-cp39-win32.whl", hash = "sha256:7970285ab628a3779aecc35823296a7869f889b8329c16ad5a71e4901a3dc4ef"},
+    {file = "pillow-10.4.0-cp39-cp39-win_amd64.whl", hash = "sha256:961a7293b2457b405967af9c77dcaa43cc1a8cd50d23c532e62d48ab6cdd56f5"},
+    {file = "pillow-10.4.0-cp39-cp39-win_arm64.whl", hash = "sha256:32cda9e3d601a52baccb2856b8ea1fc213c90b340c542dcef77140dfa3278a9e"},
+    {file = "pillow-10.4.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:5b4815f2e65b30f5fbae9dfffa8636d992d49705723fe86a3661806e069352d4"},
+    {file = "pillow-10.4.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:8f0aef4ef59694b12cadee839e2ba6afeab89c0f39a3adc02ed51d109117b8da"},
+    {file = "pillow-10.4.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9f4727572e2918acaa9077c919cbbeb73bd2b3ebcfe033b72f858fc9fbef0026"},
+    {file = "pillow-10.4.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ff25afb18123cea58a591ea0244b92eb1e61a1fd497bf6d6384f09bc3262ec3e"},
+    {file = "pillow-10.4.0-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:dc3e2db6ba09ffd7d02ae9141cfa0ae23393ee7687248d46a7507b75d610f4f5"},
+    {file = "pillow-10.4.0-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:02a2be69f9c9b8c1e97cf2713e789d4e398c751ecfd9967c18d0ce304efbf885"},
+    {file = "pillow-10.4.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:0755ffd4a0c6f267cccbae2e9903d95477ca2f77c4fcf3a3a09570001856c8a5"},
+    {file = "pillow-10.4.0-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:a02364621fe369e06200d4a16558e056fe2805d3468350df3aef21e00d26214b"},
+    {file = "pillow-10.4.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:1b5dea9831a90e9d0721ec417a80d4cbd7022093ac38a568db2dd78363b00908"},
+    {file = "pillow-10.4.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9b885f89040bb8c4a1573566bbb2f44f5c505ef6e74cec7ab9068c900047f04b"},
+    {file = "pillow-10.4.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:87dd88ded2e6d74d31e1e0a99a726a6765cda32d00ba72dc37f0651f306daaa8"},
+    {file = "pillow-10.4.0-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:2db98790afc70118bd0255c2eeb465e9767ecf1f3c25f9a1abb8ffc8cfd1fe0a"},
+    {file = "pillow-10.4.0-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:f7baece4ce06bade126fb84b8af1c33439a76d8a6fd818970215e0560ca28c27"},
+    {file = "pillow-10.4.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:cfdd747216947628af7b259d274771d84db2268ca062dd5faf373639d00113a3"},
+    {file = "pillow-10.4.0.tar.gz", hash = "sha256:166c1cd4d24309b30d61f79f4a9114b7b2313d7450912277855ff5dfd7cd4a06"},
+]
+
+[package.extras]
+docs = ["furo", "olefile", "sphinx (>=7.3)", "sphinx-copybutton", "sphinx-inline-tabs", "sphinxext-opengraph"]
+fpx = ["olefile"]
+mic = ["olefile"]
+tests = ["check-manifest", "coverage", "defusedxml", "markdown2", "olefile", "packaging", "pyroma", "pytest", "pytest-cov", "pytest-timeout"]
+typing = ["typing-extensions ; python_version < \"3.10\""]
+xmp = ["defusedxml"]
 
 [[package]]
 name = "platformdirs"
@@ -1496,6 +2083,22 @@ files = [
 
 [package.extras]
 windows-terminal = ["colorama (>=0.4.6)"]
+
+[[package]]
+name = "pyparsing"
+version = "3.3.2"
+description = "pyparsing - Classes and methods to define and execute parsing grammars"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "extra == \"graph-image\""
+files = [
+    {file = "pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d"},
+    {file = "pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc"},
+]
+
+[package.extras]
+diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pytest"
@@ -1846,6 +2449,23 @@ anyio = ">=3.6.2,<5"
 
 [package.extras]
 full = ["httpx (>=0.27.0,<0.29.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.18)", "pyyaml"]
+
+[[package]]
+name = "term-image"
+version = "0.7.2"
+description = "Display images in the terminal"
+optional = true
+python-versions = ">=3.7"
+groups = ["main"]
+markers = "extra == \"graph-image\""
+files = [
+    {file = "term_image-0.7.2-py3-none-any.whl", hash = "sha256:97d9dba5afcf3989a23b1868adc5b2de3126d1ef915df2a7859f67fbdd613e15"},
+    {file = "term_image-0.7.2.tar.gz", hash = "sha256:07320573baa667dcde145d55e94769cbaafeea43b61245245153ff5075b55ffb"},
+]
+
+[package.dependencies]
+pillow = ">=9.1,<11"
+requests = ">=2.23,<3"
 
 [[package]]
 name = "types-pyyaml"
@@ -2326,9 +2946,10 @@ test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more_it
 type = ["pytest-mypy"]
 
 [extras]
+graph-image = ["matplotlib", "networkx", "pillow", "term-image"]
 otel = ["opentelemetry-api", "opentelemetry-exporter-otlp", "opentelemetry-instrumentation-fastapi", "opentelemetry-sdk"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "e6396e502d3ae2b206ce3901b459c620cc334d8c5bf767e1bfa585cecd1a24e9"
+content-hash = "7aec1fd021646637757d0d0455d9e449dbdbf5a5b698e550fe5ca3547cc429b9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,10 +28,17 @@ opentelemetry-api = {version = "^1.20.0", optional = true}
 opentelemetry-sdk = {version = "^1.20.0", optional = true}
 opentelemetry-instrumentation-fastapi = {version = "^0.41b0", optional = true}
 opentelemetry-exporter-otlp = {version = "^1.20.0", optional = true}
+# Inline graph image rendering (optional, see graph-image extra)
+term-image = {version = ">=0.7,<1.0", optional = true}
+networkx = {version = "^3.0", optional = true}
+matplotlib = {version = "^3.7", optional = true}
+pillow = {version = "^10.0", optional = true}
 
 [tool.poetry.extras]
 # OpenTelemetry observability (optional, graceful fallback when absent)
 otel = ["opentelemetry-api", "opentelemetry-sdk", "opentelemetry-instrumentation-fastapi", "opentelemetry-exporter-otlp"]
+# Inline node-link graph images for `apollo-cli graph neighbors --image`
+graph-image = ["term-image", "networkx", "matplotlib", "pillow"]
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.0.0"
@@ -76,6 +83,11 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = ["logos_config", "logos_config.*", "logos_test_utils", "logos_test_utils.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+# Optional graph-image extra (installed via `poetry install -E graph-image`)
+module = ["term_image", "term_image.*", "networkx", "networkx.*", "matplotlib", "matplotlib.*", "PIL", "PIL.*"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/src/apollo/cli/graph_image.py
+++ b/src/apollo/cli/graph_image.py
@@ -89,30 +89,37 @@ def render_neighborhood_png(
         labels = {n: graph.nodes[n].get("label", n) for n in graph.nodes}
         node_colors = ["#e06c75" if n == root_uuid else "#61afef" for n in graph.nodes]
 
-        fig, ax = plt.subplots(figsize=(9, 7))
-        nx.draw_networkx_nodes(
-            graph, pos, node_color=node_colors, node_size=1600, ax=ax
-        )
-        nx.draw_networkx_edges(
-            graph,
-            pos,
-            ax=ax,
-            arrows=True,
-            arrowstyle="-|>",
-            arrowsize=18,
-            edge_color="#888888",
-            node_size=1600,
-        )
-        nx.draw_networkx_labels(graph, pos, labels=labels, font_size=8, ax=ax)
-        nx.draw_networkx_edge_labels(
-            graph, pos, edge_labels=edge_labels, font_size=7, ax=ax
-        )
-        ax.set_title(f"Neighborhood: {root_name or root_uuid}")
-        ax.axis("off")
-        fig.tight_layout()
-        fig.savefig(out_path, dpi=120, bbox_inches="tight")
-        plt.close(fig)
-        return True
+        # Wrap draw+save in try/finally so the figure is always closed even if
+        # layout/drawing/saving raises (matplotlib keeps a global ref to every
+        # open figure, so a leaked fig is a memory leak).
+        fig = None
+        try:
+            fig, ax = plt.subplots(figsize=(9, 7))
+            nx.draw_networkx_nodes(
+                graph, pos, node_color=node_colors, node_size=1600, ax=ax
+            )
+            nx.draw_networkx_edges(
+                graph,
+                pos,
+                ax=ax,
+                arrows=True,
+                arrowstyle="-|>",
+                arrowsize=18,
+                edge_color="#888888",
+                node_size=1600,
+            )
+            nx.draw_networkx_labels(graph, pos, labels=labels, font_size=8, ax=ax)
+            nx.draw_networkx_edge_labels(
+                graph, pos, edge_labels=edge_labels, font_size=7, ax=ax
+            )
+            ax.set_title(f"Neighborhood: {root_name or root_uuid}")
+            ax.axis("off")
+            fig.tight_layout()
+            fig.savefig(out_path, dpi=120, bbox_inches="tight")
+            return True
+        finally:
+            if fig is not None:
+                plt.close(fig)
     except Exception:
         return False
 

--- a/src/apollo/cli/graph_image.py
+++ b/src/apollo/cli/graph_image.py
@@ -1,0 +1,164 @@
+"""Optional inline graph-image rendering for the ``graph neighbors`` command.
+
+All heavy/optional dependencies (``matplotlib``, ``networkx``, ``term-image``,
+``PIL``) are imported lazily inside functions so the base install never breaks.
+Install the optional stack with ``poetry install -E graph-image``.
+
+Every public function is defensive: it returns ``False`` (never raises) when a
+dependency is missing or a step fails, so the CLI can always fall back to the
+text tree.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from typing import Any, Dict, List, Optional
+
+
+def graphics_supported() -> bool:
+    """Best-effort check for a terminal that can display inline images.
+
+    Honest and conservative: returns ``True`` only for terminals known to
+    support the kitty/iTerm2 graphics protocols or sixel.
+    """
+    if os.environ.get("KITTY_WINDOW_ID"):
+        return True
+    if os.environ.get("TERM_PROGRAM") == "iTerm.app":
+        return True
+    term = os.environ.get("TERM", "").lower()
+    if "sixel" in term or "kitty" in term:
+        return True
+    if os.environ.get("WEZTERM_PANE"):
+        return True
+    return False
+
+
+def render_neighborhood_png(
+    root_uuid: str,
+    root_name: str,
+    nodes: List[Dict[str, Any]],
+    edges: List[Dict[str, Any]],
+    out_path: str,
+) -> bool:
+    """Render the de-reified neighborhood to a PNG node-link diagram.
+
+    Uses the headless Agg backend so it works without a display. Returns
+    ``True`` on success, ``False`` (swallowing the error) if optional libs
+    are missing or rendering fails.
+    """
+    try:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+        import networkx as nx
+    except ImportError:
+        return False
+
+    try:
+        graph = nx.DiGraph()
+        graph.add_node(root_uuid, label=root_name or root_uuid[:8])
+
+        name_by_uuid: Dict[str, str] = {root_uuid: root_name or root_uuid[:8]}
+        for node in nodes:
+            uuid = node.get("uuid")
+            if not uuid:
+                continue
+            name = node.get("name") or uuid[:8]
+            name_by_uuid[uuid] = name
+            graph.add_node(uuid, label=name)
+
+        edge_labels: Dict[Any, str] = {}
+        for edge in edges:
+            source = edge.get("source")
+            target = edge.get("target")
+            relation = edge.get("relation", "")
+            if not source or not target:
+                continue
+            if source not in name_by_uuid:
+                graph.add_node(source, label=source[:8])
+                name_by_uuid[source] = source[:8]
+            if target not in name_by_uuid:
+                graph.add_node(target, label=target[:8])
+                name_by_uuid[target] = target[:8]
+            graph.add_edge(source, target, relation=relation)
+            edge_labels[(source, target)] = relation
+
+        pos = nx.spring_layout(graph, seed=42, k=0.9)
+        labels = {n: graph.nodes[n].get("label", n) for n in graph.nodes}
+        node_colors = ["#e06c75" if n == root_uuid else "#61afef" for n in graph.nodes]
+
+        fig, ax = plt.subplots(figsize=(9, 7))
+        nx.draw_networkx_nodes(
+            graph, pos, node_color=node_colors, node_size=1600, ax=ax
+        )
+        nx.draw_networkx_edges(
+            graph,
+            pos,
+            ax=ax,
+            arrows=True,
+            arrowstyle="-|>",
+            arrowsize=18,
+            edge_color="#888888",
+            node_size=1600,
+        )
+        nx.draw_networkx_labels(graph, pos, labels=labels, font_size=8, ax=ax)
+        nx.draw_networkx_edge_labels(
+            graph, pos, edge_labels=edge_labels, font_size=7, ax=ax
+        )
+        ax.set_title(f"Neighborhood: {root_name or root_uuid}")
+        ax.axis("off")
+        fig.tight_layout()
+        fig.savefig(out_path, dpi=120, bbox_inches="tight")
+        plt.close(fig)
+        return True
+    except Exception:
+        return False
+
+
+def display_png_inline(path: str) -> bool:
+    """Display a PNG inline via ``term-image``. Returns ``False`` on failure."""
+    try:
+        from term_image.image import from_file
+    except ImportError:
+        return False
+
+    try:
+        image = from_file(path)
+        print(image)
+        return True
+    except Exception:
+        return False
+
+
+def try_inline_neighborhood(
+    root_uuid: str,
+    root_name: str,
+    nodes: List[Dict[str, Any]],
+    edges: List[Dict[str, Any]],
+) -> bool:
+    """Render and display the neighborhood inline if everything is available.
+
+    Returns ``True`` only when the terminal is supported, the PNG renders, and
+    the inline display succeeds. Returns ``False`` otherwise (never raises) so
+    the CLI can fall back to the text tree.
+    """
+    if not graphics_supported():
+        return False
+
+    tmp_path: Optional[str] = None
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as handle:
+            tmp_path = handle.name
+        if not render_neighborhood_png(root_uuid, root_name, nodes, edges, tmp_path):
+            return False
+        return display_png_inline(tmp_path)
+    except Exception:
+        return False
+    finally:
+        if tmp_path and os.path.exists(tmp_path):
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass

--- a/src/apollo/cli/main.py
+++ b/src/apollo/cli/main.py
@@ -1093,11 +1093,16 @@ def graph_stats(ctx: click.Context) -> None:
         _graph_error(str(exc), "Ensure Sophia is running and SOPHIA_API_TOKEN is set")
         return
 
-    total = int(data.get("total_nodes", 0))
-    content = int(data.get("content_nodes", 0))
-    edge = int(data.get("edge_nodes", 0))
-    classified = int(data.get("content_classified", 0))
-    top_predicates = {k: int(v) for k, v in (data.get("top_predicates") or {}).items()}
+    # ``.get(key, default)`` returns ``None`` (not the default) when the key
+    # exists with an explicit null value, so coerce every numeric read with
+    # ``or 0`` to stay crash-safe on empty/partially-initialized graphs.
+    total = int(data.get("total_nodes") or 0)
+    content = int(data.get("content_nodes") or 0)
+    edge = int(data.get("edge_nodes") or 0)
+    classified = int(data.get("content_classified") or 0)
+    top_predicates = {
+        str(k): int(v or 0) for k, v in (data.get("top_predicates") or {}).items()
+    }
 
     # Distribution by ACTUAL (positional) type, not the coarse realm: drop the
     # realm roots so the bars show what the graph is about (cell, biomolecule…).
@@ -1124,7 +1129,7 @@ def graph_stats(ctx: click.Context) -> None:
     type_table = _counts_bar_table(by_type, top=12)
     predicate_table = _counts_bar_table(top_predicates, top=10)
 
-    parked = int(data.get("content_parked", 0))
+    parked = int(data.get("content_parked") or 0)
     untyped = max(content - classified - parked, 0)
     coverage = Text()
     if content:
@@ -1276,7 +1281,9 @@ def graph_node(ctx: click.Context, uuid: str) -> None:
         console.print(f"[dim]No entity found for {uuid}[/dim]")
         return
 
-    name = str(entity.get("name", uuid))
+    # Use ``or`` (not the .get default) so an explicit null name still falls
+    # back to the uuid rather than rendering the literal string "None".
+    name = str(entity.get("name") or uuid)
     # Prefer the nested properties block; otherwise dump the object minus noise.
     if isinstance(entity.get("properties"), dict):
         payload = entity["properties"]
@@ -1334,7 +1341,7 @@ def graph_neighbors(
     for node in nodes:
         nid = node.get("uuid")
         if nid:
-            name_by_uuid[nid] = str(node.get("name", nid))
+            name_by_uuid[nid] = str(node.get("name") or nid)
 
     # Best-effort root name via the entity endpoint; fall back to the uuid.
     root_name = root_uuid
@@ -1368,18 +1375,25 @@ def graph_neighbors(
             )
         tree.add(label)
 
+    # The text tree is the default. When --image succeeds we show ONLY the
+    # inline image; the tree is the fallback for --no-image / unsupported
+    # terminals / a missing optional stack.
+    show_tree = True
     if image:
         from apollo.cli.graph_image import try_inline_neighborhood
 
         rendered = try_inline_neighborhood(root_uuid, root_name, nodes, edges)
-        if not rendered:
+        if rendered:
+            show_tree = False
+        else:
             console.print(
                 "[dim]graph-image unavailable; showing tree "
                 "(install extra: poetry install -E graph-image, and use a "
                 "kitty/iTerm2/sixel terminal)[/dim]"
             )
 
-    console.print(tree)
+    if show_tree:
+        console.print(tree)
 
 
 def main() -> None:

--- a/src/apollo/cli/main.py
+++ b/src/apollo/cli/main.py
@@ -1088,6 +1088,7 @@ def graph_stats(ctx: click.Context) -> None:
     client = _graph_client(ctx)
     try:
         data = client.stats()
+        type_rows = client.types(limit=2000)
     except HCGQueryError as exc:
         _graph_error(str(exc), "Ensure Sophia is running and SOPHIA_API_TOKEN is set")
         return
@@ -1095,8 +1096,17 @@ def graph_stats(ctx: click.Context) -> None:
     total = int(data.get("total_nodes", 0))
     content = int(data.get("content_nodes", 0))
     edge = int(data.get("edge_nodes", 0))
-    by_realm = {k: int(v) for k, v in (data.get("by_realm") or {}).items()}
+    classified = int(data.get("content_classified", 0))
     top_predicates = {k: int(v) for k, v in (data.get("top_predicates") or {}).items()}
+
+    # Distribution by ACTUAL (positional) type, not the coarse realm: drop the
+    # realm roots so the bars show what the graph is about (cell, biomolecule…).
+    realms = {"entity", "concept", "process", "node", "root"}
+    by_type = {
+        str(r["name"]): int(r.get("member_count") or 0)
+        for r in type_rows
+        if r.get("name") and r["name"] not in realms
+    }
 
     headline = Text()
     headline.append("Total nodes: ", style="bold")
@@ -1111,8 +1121,21 @@ def graph_stats(ctx: click.Context) -> None:
     legend.append("  ")
     legend.append("█ edge-nodes", style="magenta")
 
-    realm_table = _counts_bar_table(by_realm, top=10)
+    type_table = _counts_bar_table(by_type, top=12)
     predicate_table = _counts_bar_table(top_predicates, top=10)
+
+    parked = int(data.get("content_parked", 0))
+    untyped = max(content - classified - parked, 0)
+    coverage = Text()
+    if content:
+        pct = round(100 * classified / content)
+        coverage.append("Typing coverage: ", style="bold")
+        coverage.append(f"{classified}/{content} ({pct}%)", style="cyan")
+        coverage.append(" under a specific type · ")
+        coverage.append(f"{parked} parked under a realm", style="dim")
+        if untyped:
+            coverage.append(" · ")
+            coverage.append(f"{untyped} untyped", style="yellow")
 
     body = Group(
         headline,
@@ -1120,8 +1143,10 @@ def graph_stats(ctx: click.Context) -> None:
         _proportion_bar(content, edge),
         legend,
         Text(""),
-        Text("By realm (top 10):", style="bold underline"),
-        realm_table,
+        coverage,
+        Text(""),
+        Text("Top types by membership (positional):", style="bold underline"),
+        type_table,
         Text(""),
         Text("Top predicates (top 10):", style="bold underline"),
         predicate_table,

--- a/src/apollo/cli/main.py
+++ b/src/apollo/cli/main.py
@@ -1136,14 +1136,30 @@ def graph_types(ctx: click.Context, limit: int) -> None:
     """Show the positional type hierarchy as a tree."""
     client = _graph_client(ctx)
     try:
-        rows = client.types(limit=limit)
+        # Fetch the full (small) type layer so the tree can be rooted correctly.
+        # --limit then bounds what we DISPLAY, not what we fetch: we show the top
+        # `limit` types by membership PLUS each one's ancestor chain, so a shown
+        # type's parent is always present and children don't orphan to the root.
+        all_rows = client.types(limit=2000)
     except HCGQueryError as exc:
         _graph_error(str(exc), "Ensure Sophia is running and SOPHIA_API_TOKEN is set")
         return
 
-    if not rows:
+    if not all_rows:
         console.print("[dim]No type definitions returned[/dim]")
         return
+
+    full_by_name: Dict[str, Dict[str, Any]] = {
+        r["name"]: r for r in all_rows if r.get("name")
+    }
+    top = sorted(all_rows, key=lambda r: -(r.get("member_count") or 0))[:limit]
+    keep: set = set()
+    for r in top:
+        nm = r.get("name")
+        while nm and nm in full_by_name and nm not in keep:
+            keep.add(nm)
+            nm = full_by_name[nm].get("parent")
+    rows = [r for r in all_rows if r.get("name") in keep]
 
     # Index rows by name and build parent -> children adjacency.
     by_name: Dict[str, Dict[str, Any]] = {}

--- a/src/apollo/cli/main.py
+++ b/src/apollo/cli/main.py
@@ -7,9 +7,12 @@ import time
 import click
 import requests
 from rich.console import Console
+from rich.console import Group
 from rich.table import Table
 from rich.panel import Panel
 from rich.syntax import Syntax
+from rich.text import Text
+from rich.tree import Tree
 import yaml
 from logos_hermes_sdk.models.llm_message import LLMMessage
 from logos_hermes_sdk.models.llm_request import LLMRequest
@@ -17,6 +20,7 @@ from logos_hermes_sdk.models.llm_request import LLMRequest
 from apollo.client.sophia_client import SophiaClient
 from apollo.client.hermes_client import HermesClient, HermesResponse
 from apollo.client.persona_client import PersonaClient
+from apollo.client.hcg_query_client import HCGQueryClient, HCGQueryError
 from apollo.config.settings import ApolloConfig, PersonaApiConfig
 
 import os
@@ -1018,6 +1022,323 @@ def _persona_api_base_url(config: PersonaApiConfig) -> str:
     if config.host.startswith(("http://", "https://")):
         return config.host.rstrip("/")
     return f"http://{config.host}:{config.port}"
+
+
+def _graph_client(ctx: click.Context) -> HCGQueryClient:
+    """Lazily build an HCGQueryClient from the loaded Apollo config.
+
+    Built per-command (not in the root group) so commands that mock a config
+    without graph support are unaffected.
+    """
+    config: ApolloConfig = ctx.obj["config"]
+    return HCGQueryClient(config.sophia)
+
+
+def _graph_error(message: str, tip: str) -> None:
+    """Print a graph command error in the standard red + dim-tip style."""
+    console.print(f"[red]✗ Error:[/red] {message}")
+    console.print(f"\n[dim]Tip: {tip}[/dim]")
+
+
+def _proportion_bar(content: int, edge: int, width: int = 40) -> Text:
+    """Build a two-tone horizontal bar splitting ``width`` between two counts."""
+    total = content + edge
+    bar = Text()
+    if total <= 0:
+        bar.append("█" * width, style="dim")
+        return bar
+    content_cells = round(width * content / total)
+    content_cells = max(0, min(width, content_cells))
+    edge_cells = width - content_cells
+    bar.append("█" * content_cells, style="cyan")
+    bar.append("█" * edge_cells, style="magenta")
+    return bar
+
+
+def _counts_bar_table(data: Dict[str, int], top: int = 10) -> Table:
+    """Render a compact label/bar/count table scaled to the max count."""
+    table = Table(show_header=False, box=None, pad_edge=False)
+    table.add_column("label", style="bold")
+    table.add_column("bar")
+    table.add_column("count", justify="right", style="dim")
+
+    items = sorted(data.items(), key=lambda kv: kv[1], reverse=True)[:top]
+    max_count = max((count for _, count in items), default=0)
+    max_width = 24
+    for label, count in items:
+        if max_count > 0:
+            cells = max(1, round(max_width * count / max_count))
+        else:
+            cells = 0
+        bar = Text("█" * cells, style="green")
+        table.add_row(str(label), bar, str(count))
+    return table
+
+
+@cli.group()
+@click.pass_context
+def graph(ctx: click.Context) -> None:
+    """Query the Hybrid Causal Graph via Sophia."""
+
+
+@graph.command("stats")
+@click.pass_context
+def graph_stats(ctx: click.Context) -> None:
+    """Show graph-wide statistics with proportion bars."""
+    client = _graph_client(ctx)
+    try:
+        data = client.stats()
+    except HCGQueryError as exc:
+        _graph_error(str(exc), "Ensure Sophia is running and SOPHIA_API_TOKEN is set")
+        return
+
+    total = int(data.get("total_nodes", 0))
+    content = int(data.get("content_nodes", 0))
+    edge = int(data.get("edge_nodes", 0))
+    by_realm = {k: int(v) for k, v in (data.get("by_realm") or {}).items()}
+    top_predicates = {k: int(v) for k, v in (data.get("top_predicates") or {}).items()}
+
+    headline = Text()
+    headline.append("Total nodes: ", style="bold")
+    headline.append(str(total), style="bold white")
+    headline.append("  =  ")
+    headline.append(f"{content} content", style="cyan")
+    headline.append("  +  ")
+    headline.append(f"{edge} edge-nodes", style="magenta")
+
+    legend = Text()
+    legend.append("█ content ", style="cyan")
+    legend.append("  ")
+    legend.append("█ edge-nodes", style="magenta")
+
+    realm_table = _counts_bar_table(by_realm, top=10)
+    predicate_table = _counts_bar_table(top_predicates, top=10)
+
+    body = Group(
+        headline,
+        Text(""),
+        _proportion_bar(content, edge),
+        legend,
+        Text(""),
+        Text("By realm (top 10):", style="bold underline"),
+        realm_table,
+        Text(""),
+        Text("Top predicates (top 10):", style="bold underline"),
+        predicate_table,
+    )
+    console.print(Panel(body, title="HCG Stats", border_style="cyan"))
+
+
+@graph.command("types")
+@click.option("--limit", default=20, show_default=True, help="Max type rows to fetch")
+@click.pass_context
+def graph_types(ctx: click.Context, limit: int) -> None:
+    """Show the positional type hierarchy as a tree."""
+    client = _graph_client(ctx)
+    try:
+        rows = client.types(limit=limit)
+    except HCGQueryError as exc:
+        _graph_error(str(exc), "Ensure Sophia is running and SOPHIA_API_TOKEN is set")
+        return
+
+    if not rows:
+        console.print("[dim]No type definitions returned[/dim]")
+        return
+
+    # Index rows by name and build parent -> children adjacency.
+    by_name: Dict[str, Dict[str, Any]] = {}
+    for row in rows:
+        name = row.get("name")
+        if name:
+            by_name[name] = row
+
+    children: Dict[str, List[Dict[str, Any]]] = {}
+    roots: List[Dict[str, Any]] = []
+    for row in rows:
+        parent = row.get("parent")
+        if parent and parent in by_name:
+            children.setdefault(parent, []).append(row)
+        else:
+            # parent is null OR points outside the fetched set -> treat as root
+            roots.append(row)
+
+    def _label(row: Dict[str, Any]) -> str:
+        name = str(row.get("name", "?"))
+        count = row.get("member_count")
+        if count is not None:
+            return f"{name} [dim]({count})[/dim]"
+        return name
+
+    tree = Tree("[bold]Type hierarchy[/bold]")
+
+    def _attach(parent_branch: Tree, row: Dict[str, Any], seen: set) -> None:
+        name = str(row.get("name", ""))
+        if name in seen:  # guard against cycles
+            parent_branch.add(f"{_label(row)} [red](cycle)[/red]")
+            return
+        seen = seen | {name}
+        branch = parent_branch.add(_label(row))
+        for child in sorted(
+            children.get(name, []), key=lambda r: str(r.get("name", ""))
+        ):
+            _attach(branch, child, seen)
+
+    for root in sorted(roots, key=lambda r: str(r.get("name", ""))):
+        _attach(tree, root, set())
+
+    console.print(tree)
+
+
+@graph.command("search")
+@click.argument("query")
+@click.option("--limit", default=10, show_default=True, help="Max results")
+@click.pass_context
+def graph_search(ctx: click.Context, query: str, limit: int) -> None:
+    """Search the graph for nodes matching QUERY."""
+    client = _graph_client(ctx)
+    try:
+        results = client.search(query, limit=limit)
+    except HCGQueryError as exc:
+        _graph_error(str(exc), "Ensure Sophia is running and SOPHIA_API_TOKEN is set")
+        return
+
+    if not results:
+        console.print(f"[dim]No results for '{query}'[/dim]")
+        return
+
+    table = Table(show_header=True, header_style="bold cyan")
+    table.add_column("UUID", style="dim")
+    table.add_column("Name")
+    table.add_column("Type", justify="center")
+    for hit in results:
+        table.add_row(
+            str(hit.get("uuid", "—")),
+            str(hit.get("name", "—")),
+            str(hit.get("type", "—")),
+        )
+    console.print(table)
+
+
+@graph.command("node")
+@click.argument("uuid")
+@click.pass_context
+def graph_node(ctx: click.Context, uuid: str) -> None:
+    """Show a single entity's properties as highlighted YAML."""
+    client = _graph_client(ctx)
+    try:
+        entity = client.entity(uuid)
+    except HCGQueryError as exc:
+        _graph_error(str(exc), "Check the UUID and that Sophia is running")
+        return
+
+    if not entity:
+        console.print(f"[dim]No entity found for {uuid}[/dim]")
+        return
+
+    name = str(entity.get("name", uuid))
+    # Prefer the nested properties block; otherwise dump the object minus noise.
+    if isinstance(entity.get("properties"), dict):
+        payload = entity["properties"]
+    else:
+        payload = {
+            k: v for k, v in entity.items() if k not in ("embedding", "embedding_2d")
+        }
+
+    api_url = f"{client.base_url}/hcg/entities/{uuid}"
+    link_line = Text()
+    link_line.append("uuid: ", style="dim")
+    link_line.append(uuid, style=f"link {api_url}")
+
+    entity_text = yaml.dump(payload, default_flow_style=False, sort_keys=False)
+    syntax = Syntax(entity_text, "yaml", theme="monokai", line_numbers=False)
+    body = Group(link_line, Text(""), syntax)
+    console.print(
+        Panel(
+            body,
+            title=f"Entity {name}",
+            subtitle=f"[link={api_url}]{uuid}[/link]",
+            border_style="green",
+        )
+    )
+
+
+@graph.command("neighbors")
+@click.argument("uuid")
+@click.option("--depth", default=1, show_default=True, help="Neighborhood depth")
+@click.option("--limit", default=25, show_default=True, help="Max neighbors")
+@click.option(
+    "--image/--no-image",
+    default=False,
+    help="Render an inline node-link image when the terminal supports it",
+)
+@click.pass_context
+def graph_neighbors(
+    ctx: click.Context, uuid: str, depth: int, limit: int, image: bool
+) -> None:
+    """Show a node's de-reified neighborhood as a directional tree."""
+    client = _graph_client(ctx)
+    try:
+        data = client.neighborhood(uuid, depth=depth, limit=limit)
+    except HCGQueryError as exc:
+        _graph_error(str(exc), "Check the UUID and that Sophia is running")
+        return
+
+    nodes = data.get("nodes") or []
+    edges = data.get("edges") or []
+    metadata = data.get("metadata") or {}
+    root_uuid = str(metadata.get("root", uuid))
+
+    # Build uuid -> name map from neighbors (root is NOT in nodes).
+    name_by_uuid: Dict[str, str] = {}
+    for node in nodes:
+        nid = node.get("uuid")
+        if nid:
+            name_by_uuid[nid] = str(node.get("name", nid))
+
+    # Best-effort root name via the entity endpoint; fall back to the uuid.
+    root_name = root_uuid
+    try:
+        root_entity = client.entity(root_uuid)
+        if root_entity.get("name"):
+            root_name = str(root_entity["name"])
+    except HCGQueryError:
+        pass
+
+    def _short(value: str) -> str:
+        return value[:8]
+
+    tree = Tree(f"[bold]{root_name}[/bold] [dim]({_short(root_uuid)})[/dim]")
+    for edge in edges:
+        source = edge.get("source")
+        target = edge.get("target")
+        relation = str(edge.get("relation", ""))
+        if source == root_uuid:
+            other = str(target)
+            label = f"─{relation}→ " f"{name_by_uuid.get(other, _short(other))}"
+        elif target == root_uuid:
+            other = str(source)
+            label = f"←{relation}─ " f"{name_by_uuid.get(other, _short(other))}"
+        else:
+            # Edge not incident to root (shouldn't normally happen); show raw.
+            label = (
+                f"{name_by_uuid.get(str(source), _short(str(source)))} "
+                f"─{relation}→ "
+                f"{name_by_uuid.get(str(target), _short(str(target)))}"
+            )
+        tree.add(label)
+
+    if image:
+        from apollo.cli.graph_image import try_inline_neighborhood
+
+        rendered = try_inline_neighborhood(root_uuid, root_name, nodes, edges)
+        if not rendered:
+            console.print(
+                "[dim]graph-image unavailable; showing tree "
+                "(install extra: poetry install -E graph-image, and use a "
+                "kitty/iTerm2/sixel terminal)[/dim]"
+            )
+
+    console.print(tree)
 
 
 def main() -> None:

--- a/src/apollo/cli/main.py
+++ b/src/apollo/cli/main.py
@@ -1334,7 +1334,10 @@ def graph_neighbors(
     nodes = data.get("nodes") or []
     edges = data.get("edges") or []
     metadata = data.get("metadata") or {}
-    root_uuid = str(metadata.get("root", uuid))
+    # `or uuid` (not a .get default): sophia may return {"root": null}, and a
+    # default arg only fires when the key is absent -- a null would make every
+    # `source == root_uuid` comparison miss and render the root as "None".
+    root_uuid = str(metadata.get("root") or uuid)
 
     # Build uuid -> name map from neighbors (root is NOT in nodes).
     name_by_uuid: Dict[str, str] = {}

--- a/src/apollo/client/hcg_query_client.py
+++ b/src/apollo/client/hcg_query_client.py
@@ -1,0 +1,108 @@
+"""Thin HTTP client for Sophia's Hybrid Causal Graph (``/hcg/*``) endpoints.
+
+Sophia is the Neo4j gatekeeper: this client never touches Neo4j directly,
+it only issues authenticated HTTP requests against Sophia's read API. It is
+intentionally separate from :class:`apollo.data.HCGClient` (the Neo4j-based
+client) to avoid coupling the CLI to a database driver.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from apollo.config.settings import SophiaConfig
+
+
+class HCGQueryError(Exception):
+    """Raised when an HCG HTTP query fails (connection or HTTP error)."""
+
+
+def _normalize_base_url(host: str, port: int) -> str:
+    """Build a base URL, honouring a fully-qualified host if provided."""
+    if host.startswith(("http://", "https://")):
+        return host.rstrip("/")
+    return f"http://{host}:{port}"
+
+
+def _build_headers(api_key: Optional[str]) -> Dict[str, str]:
+    """Build request headers, including bearer auth only when a key is set."""
+    headers = {"Accept": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    return headers
+
+
+class HCGQueryClient:
+    """Read-only HTTP client for Sophia's HCG endpoints."""
+
+    def __init__(self, config: SophiaConfig) -> None:
+        self.config = config
+        self.base_url = _normalize_base_url(config.host, config.port)
+        self.timeout = config.timeout
+        self._headers = _build_headers(config.api_key)
+
+    def _get(self, path: str, params: Optional[Dict[str, Any]] = None) -> Any:
+        """Issue a GET request and return parsed JSON, raising on failure."""
+        url = f"{self.base_url}{path}"
+        try:
+            response = requests.get(
+                url,
+                params=params,
+                headers=self._headers,
+                timeout=self.timeout,
+            )
+        except requests.RequestException as exc:
+            raise HCGQueryError(
+                f"Failed to reach Sophia HCG endpoint {url}: {exc}"
+            ) from exc
+
+        try:
+            response.raise_for_status()
+        except requests.HTTPError as exc:
+            snippet = (response.text or "").strip()
+            if len(snippet) > 200:
+                snippet = f"{snippet[:200]}..."
+            detail = f" - {snippet}" if snippet else ""
+            raise HCGQueryError(
+                f"Sophia HCG request to {url} failed with status "
+                f"{response.status_code}{detail}"
+            ) from exc
+
+        try:
+            return response.json()
+        except ValueError as exc:
+            raise HCGQueryError(
+                f"Sophia HCG response from {url} was not valid JSON: {exc}"
+            ) from exc
+
+    def stats(self) -> Dict[str, Any]:
+        """Return graph-wide statistics from ``GET /hcg/stats``."""
+        result = self._get("/hcg/stats")
+        return result if isinstance(result, dict) else {}
+
+    def types(self, limit: int = 50) -> List[Dict[str, Any]]:
+        """Return type definitions from ``GET /hcg/types``."""
+        result = self._get("/hcg/types", params={"limit": limit})
+        return result if isinstance(result, list) else []
+
+    def neighborhood(
+        self, uuid: str, depth: int = 1, limit: int = 25
+    ) -> Dict[str, Any]:
+        """Return a node's de-reified neighborhood from ``/hcg/neighborhood``."""
+        result = self._get(
+            f"/hcg/neighborhood/{uuid}",
+            params={"depth": depth, "limit": limit},
+        )
+        return result if isinstance(result, dict) else {}
+
+    def search(self, q: str, limit: int = 10) -> List[Dict[str, Any]]:
+        """Return search hits from ``GET /hcg/search``."""
+        result = self._get("/hcg/search", params={"q": q, "limit": limit})
+        return result if isinstance(result, list) else []
+
+    def entity(self, uuid: str) -> Dict[str, Any]:
+        """Return an entity object from ``GET /hcg/entities/{uuid}``."""
+        result = self._get(f"/hcg/entities/{uuid}")
+        return result if isinstance(result, dict) else {}

--- a/src/apollo/config/settings.py
+++ b/src/apollo/config/settings.py
@@ -30,6 +30,15 @@ def _get_client_host(env_var: str, default: str = "localhost") -> str:
     return "localhost" if host == "0.0.0.0" else host
 
 
+def _resolve_sophia_token() -> Optional[str]:
+    """Resolve the Sophia bearer token from the environment.
+
+    Prefers the canonical ``SOPHIA_API_TOKEN`` and falls back to the
+    legacy ``SOPHIA_API_KEY`` when the canonical variable is unset.
+    """
+    return os.getenv("SOPHIA_API_TOKEN") or os.getenv("SOPHIA_API_KEY")
+
+
 class SophiaConfig(BaseModel):
     """Configuration for Sophia cognitive core connection."""
 
@@ -46,7 +55,7 @@ class SophiaConfig(BaseModel):
     )
     timeout: int = Field(default=30, description="Request timeout in seconds")
     api_key: Optional[str] = Field(
-        default_factory=lambda: os.getenv("SOPHIA_API_KEY"),
+        default_factory=_resolve_sophia_token,
         description="Bearer token for Sophia API access",
     )
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -3,6 +3,8 @@
 import os
 from unittest.mock import patch
 
+import pytest
+
 from apollo.config.settings import (
     ApolloConfig,
     HCGConfig,
@@ -113,16 +115,17 @@ def test_sophia_api_token_used_when_set() -> None:
         assert config.api_key == "canonical-token"
 
 
-def test_sophia_api_token_falls_back_to_api_key() -> None:
+def test_sophia_api_token_falls_back_to_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """api_key falls back to SOPHIA_API_KEY when only that is set."""
-    with patch.dict(
-        os.environ,
-        {"SOPHIA_API_KEY": "legacy-key"},
-        clear=False,
-    ):
-        os.environ.pop("SOPHIA_API_TOKEN", None)
-        config = SophiaConfig()
-        assert config.api_key == "legacy-key"
+    # Use monkeypatch.delenv rather than mutating the live os.environ inside a
+    # patch.dict context: the latter is fragile under parallel test execution
+    # (e.g. pytest-xdist) where workers share the process.
+    monkeypatch.setenv("SOPHIA_API_KEY", "legacy-key")
+    monkeypatch.delenv("SOPHIA_API_TOKEN", raising=False)
+    config = SophiaConfig()
+    assert config.api_key == "legacy-key"
 
 
 def test_sophia_api_token_precedence_over_api_key() -> None:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -100,3 +100,37 @@ def test_apollo_config_load() -> None:
     config = ApolloConfig.load()
     assert isinstance(config, ApolloConfig)
     assert isinstance(config.sophia, SophiaConfig)
+
+
+def test_sophia_api_token_used_when_set() -> None:
+    """SOPHIA_API_TOKEN populates api_key when present."""
+    with patch.dict(
+        os.environ,
+        {"SOPHIA_API_TOKEN": "canonical-token"},
+        clear=False,
+    ):
+        config = SophiaConfig()
+        assert config.api_key == "canonical-token"
+
+
+def test_sophia_api_token_falls_back_to_api_key() -> None:
+    """api_key falls back to SOPHIA_API_KEY when only that is set."""
+    with patch.dict(
+        os.environ,
+        {"SOPHIA_API_KEY": "legacy-key"},
+        clear=False,
+    ):
+        os.environ.pop("SOPHIA_API_TOKEN", None)
+        config = SophiaConfig()
+        assert config.api_key == "legacy-key"
+
+
+def test_sophia_api_token_precedence_over_api_key() -> None:
+    """SOPHIA_API_TOKEN wins over SOPHIA_API_KEY when both are set."""
+    with patch.dict(
+        os.environ,
+        {"SOPHIA_API_TOKEN": "canonical-token", "SOPHIA_API_KEY": "legacy-key"},
+        clear=False,
+    ):
+        config = SophiaConfig()
+        assert config.api_key == "canonical-token"

--- a/tests/unit/test_graph_cli.py
+++ b/tests/unit/test_graph_cli.py
@@ -1,0 +1,261 @@
+"""Unit tests for the ``apollo-cli graph`` command group.
+
+These drive the Click commands via :class:`click.testing.CliRunner` with a
+mocked :class:`HCGQueryClient`, so they cover the rendering / null-coercion /
+fallback logic without a live Sophia. The ``graph`` group callback is a no-op,
+so invoking it with ``obj={"config": ...}`` bypasses the root ``cli`` callback
+(which would otherwise construct real network clients).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+from unittest.mock import Mock, patch
+
+from click.testing import CliRunner
+
+from apollo.cli.main import graph
+from apollo.client.hcg_query_client import HCGQueryError
+
+
+def _run(args, client: Mock):
+    """Invoke a ``graph`` subcommand with ``_graph_client`` patched."""
+    runner = CliRunner()
+    with patch("apollo.cli.main._graph_client", return_value=client):
+        return runner.invoke(graph, args, obj={"config": object()})
+
+
+# --- graph stats ---------------------------------------------------------
+
+
+def test_stats_renders_headline_and_tables() -> None:
+    client = Mock()
+    client.stats.return_value = {
+        "total_nodes": 100,
+        "content_nodes": 80,
+        "edge_nodes": 20,
+        "content_classified": 50,
+        "content_parked": 10,
+        "top_predicates": {"causes": 5, "partOf": 3},
+    }
+    client.types.return_value = [
+        {"name": "cell", "member_count": 40},
+        {"name": "entity", "member_count": 99},  # realm root -> dropped
+    ]
+    result = _run(["stats"], client)
+    assert result.exit_code == 0, result.output
+    assert "HCG Stats" in result.output
+    assert "Total nodes" in result.output
+
+
+def test_stats_survives_null_counts() -> None:
+    """Sophia returning explicit nulls must not crash int() coercion."""
+    client = Mock()
+    client.stats.return_value = {
+        "total_nodes": None,
+        "content_nodes": None,
+        "edge_nodes": None,
+        "content_classified": None,
+        "content_parked": None,
+        "top_predicates": {"causes": None},
+    }
+    client.types.return_value = [{"name": "cell", "member_count": None}]
+    result = _run(["stats"], client)
+    assert result.exit_code == 0, result.output
+    assert "HCG Stats" in result.output
+
+
+def test_stats_handles_query_error() -> None:
+    client = Mock()
+    client.stats.side_effect = HCGQueryError("connection refused")
+    result = _run(["stats"], client)
+    assert result.exit_code == 0
+    assert "Error" in result.output
+    assert "connection refused" in result.output
+
+
+# --- graph types ---------------------------------------------------------
+
+
+def test_types_renders_tree() -> None:
+    client = Mock()
+    client.types.return_value = [
+        {"name": "entity", "parent": None, "member_count": 10},
+        {"name": "cell", "parent": "entity", "member_count": 5},
+    ]
+    result = _run(["types", "--limit", "10"], client)
+    assert result.exit_code == 0, result.output
+    assert "Type hierarchy" in result.output
+    assert "cell" in result.output
+
+
+def test_types_empty() -> None:
+    client = Mock()
+    client.types.return_value = []
+    result = _run(["types"], client)
+    assert result.exit_code == 0
+    assert "No type definitions" in result.output
+
+
+def test_types_handles_query_error() -> None:
+    client = Mock()
+    client.types.side_effect = HCGQueryError("boom")
+    result = _run(["types"], client)
+    assert result.exit_code == 0
+    assert "Error" in result.output
+
+
+# --- graph search --------------------------------------------------------
+
+
+def test_search_renders_table() -> None:
+    client = Mock()
+    client.search.return_value = [
+        {"uuid": "u1", "name": "Cell", "type": "cell"},
+    ]
+    result = _run(["search", "cell"], client)
+    assert result.exit_code == 0, result.output
+    assert "Cell" in result.output
+
+
+def test_search_no_results() -> None:
+    client = Mock()
+    client.search.return_value = []
+    result = _run(["search", "nope"], client)
+    assert result.exit_code == 0
+    assert "No results" in result.output
+
+
+def test_search_handles_query_error() -> None:
+    client = Mock()
+    client.search.side_effect = HCGQueryError("boom")
+    result = _run(["search", "x"], client)
+    assert result.exit_code == 0
+    assert "Error" in result.output
+
+
+# --- graph node ----------------------------------------------------------
+
+
+def test_node_renders_entity() -> None:
+    client = Mock()
+    client.base_url = "http://localhost:47000"
+    client.entity.return_value = {
+        "name": "Cell",
+        "properties": {"kind": "biological"},
+    }
+    result = _run(["node", "u1"], client)
+    assert result.exit_code == 0, result.output
+    assert "Cell" in result.output
+
+
+def test_node_null_name_falls_back_to_uuid() -> None:
+    client = Mock()
+    client.base_url = "http://localhost:47000"
+    client.entity.return_value = {"name": None, "value": 1}
+    result = _run(["node", "uuid-xyz"], client)
+    assert result.exit_code == 0, result.output
+    # Must not render the literal "None" as the panel title.
+    assert "Entity None" not in result.output
+    assert "uuid-xyz" in result.output
+
+
+def test_node_not_found() -> None:
+    client = Mock()
+    client.base_url = "http://localhost:47000"
+    client.entity.return_value = {}
+    result = _run(["node", "missing"], client)
+    assert result.exit_code == 0
+    assert "No entity found" in result.output
+
+
+def test_node_handles_query_error() -> None:
+    client = Mock()
+    client.entity.side_effect = HCGQueryError("bad uuid")
+    result = _run(["node", "x"], client)
+    assert result.exit_code == 0
+    assert "Error" in result.output
+
+
+# --- graph neighbors -----------------------------------------------------
+
+
+def _neighborhood() -> Dict[str, Any]:
+    return {
+        "nodes": [{"uuid": "n1", "name": "Neighbor"}],
+        "edges": [{"source": "root", "target": "n1", "relation": "causes"}],
+        "metadata": {"root": "root"},
+    }
+
+
+def test_neighbors_renders_tree_by_default() -> None:
+    client = Mock()
+    client.neighborhood.return_value = _neighborhood()
+    client.entity.return_value = {"name": "RootNode"}
+    result = _run(["neighbors", "root"], client)
+    assert result.exit_code == 0, result.output
+    assert "RootNode" in result.output
+    assert "causes" in result.output
+
+
+def test_neighbors_null_neighbor_name_falls_back_to_uuid() -> None:
+    client = Mock()
+    data = _neighborhood()
+    data["nodes"] = [{"uuid": "n1", "name": None}]
+    client.neighborhood.return_value = data
+    client.entity.return_value = {"name": "RootNode"}
+    result = _run(["neighbors", "root"], client)
+    assert result.exit_code == 0, result.output
+    # The null neighbor name must not surface as the literal "None".
+    assert "None" not in result.output
+
+
+def test_neighbors_image_success_suppresses_tree() -> None:
+    """--image rendering must show ONLY the image, not also the tree."""
+    client = Mock()
+    client.neighborhood.return_value = _neighborhood()
+    client.entity.return_value = {"name": "RootNode"}
+    runner = CliRunner()
+    with patch("apollo.cli.main._graph_client", return_value=client):
+        with patch("apollo.cli.graph_image.try_inline_neighborhood", return_value=True):
+            result = runner.invoke(
+                graph, ["neighbors", "root", "--image"], obj={"config": object()}
+            )
+    assert result.exit_code == 0, result.output
+    # Tree was suppressed: the relation label only appears in the tree.
+    assert "causes" not in result.output
+
+
+def test_neighbors_image_failure_falls_back_to_tree() -> None:
+    client = Mock()
+    client.neighborhood.return_value = _neighborhood()
+    client.entity.return_value = {"name": "RootNode"}
+    runner = CliRunner()
+    with patch("apollo.cli.main._graph_client", return_value=client):
+        with patch(
+            "apollo.cli.graph_image.try_inline_neighborhood", return_value=False
+        ):
+            result = runner.invoke(
+                graph, ["neighbors", "root", "--image"], obj={"config": object()}
+            )
+    assert result.exit_code == 0, result.output
+    assert "graph-image unavailable" in result.output
+    assert "causes" in result.output  # tree fallback shown
+
+
+def test_neighbors_handles_query_error() -> None:
+    client = Mock()
+    client.neighborhood.side_effect = HCGQueryError("bad uuid")
+    result = _run(["neighbors", "x"], client)
+    assert result.exit_code == 0
+    assert "Error" in result.output
+
+
+def test_neighbors_root_entity_error_is_tolerated() -> None:
+    """A failure fetching the root entity name must not crash the command."""
+    client = Mock()
+    client.neighborhood.return_value = _neighborhood()
+    client.entity.side_effect = HCGQueryError("root lookup failed")
+    result = _run(["neighbors", "root"], client)
+    assert result.exit_code == 0, result.output
+    assert "causes" in result.output

--- a/tests/unit/test_graph_cli.py
+++ b/tests/unit/test_graph_cli.py
@@ -210,6 +210,23 @@ def test_neighbors_null_neighbor_name_falls_back_to_uuid() -> None:
     assert "None" not in result.output
 
 
+def test_neighbors_null_root_metadata_falls_back_to_uuid() -> None:
+    """sophia returning {"root": null} must fall back to the requested uuid,
+    not render the tree root as the literal "None"."""
+    client = Mock()
+    client.neighborhood.return_value = {
+        "nodes": [{"uuid": "n1", "name": "Neighbor"}],
+        "edges": [{"source": "abc-123", "target": "n1", "relation": "causes"}],
+        "metadata": {"root": None},
+    }
+    client.entity.return_value = {}  # no name -> root label falls back to the uuid
+    result = _run(["neighbors", "abc-123"], client)
+    assert result.exit_code == 0, result.output
+    assert "None" not in result.output
+    assert "abc-123" in result.output
+    assert "causes" in result.output
+
+
 def test_neighbors_image_success_suppresses_tree() -> None:
     """--image rendering must show ONLY the image, not also the tree."""
     client = Mock()

--- a/tests/unit/test_graph_image.py
+++ b/tests/unit/test_graph_image.py
@@ -1,0 +1,104 @@
+"""Unit tests for :mod:`apollo.cli.graph_image`.
+
+The module is intentionally defensive: every public function returns ``False``
+(never raises) when an optional dependency or the terminal is missing, so the
+CLI can always fall back to the text tree. These tests pin that contract,
+focusing on the fallback paths that run in CI (no graphics terminal, optional
+libs absent).
+"""
+
+from __future__ import annotations
+
+import builtins
+from typing import Any, List
+from unittest.mock import patch
+
+from apollo.cli import graph_image
+
+
+# --- graphics_supported --------------------------------------------------
+
+
+def test_graphics_supported_false_for_plain_terminal(monkeypatch) -> None:
+    for var in ("KITTY_WINDOW_ID", "TERM_PROGRAM", "WEZTERM_PANE"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("TERM", "xterm-256color")
+    assert graph_image.graphics_supported() is False
+
+
+def test_graphics_supported_kitty_window(monkeypatch) -> None:
+    monkeypatch.setenv("KITTY_WINDOW_ID", "1")
+    assert graph_image.graphics_supported() is True
+
+
+def test_graphics_supported_iterm(monkeypatch) -> None:
+    monkeypatch.delenv("KITTY_WINDOW_ID", raising=False)
+    monkeypatch.setenv("TERM_PROGRAM", "iTerm.app")
+    assert graph_image.graphics_supported() is True
+
+
+def test_graphics_supported_sixel_term(monkeypatch) -> None:
+    for var in ("KITTY_WINDOW_ID", "TERM_PROGRAM", "WEZTERM_PANE"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("TERM", "xterm-sixel")
+    assert graph_image.graphics_supported() is True
+
+
+def test_graphics_supported_wezterm(monkeypatch) -> None:
+    for var in ("KITTY_WINDOW_ID", "TERM_PROGRAM"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("TERM", "xterm")
+    monkeypatch.setenv("WEZTERM_PANE", "0")
+    assert graph_image.graphics_supported() is True
+
+
+# --- render_neighborhood_png (lib-missing fallback) ----------------------
+
+
+def _force_missing(*names: str):
+    """Patch __import__ so the named modules raise ImportError."""
+    real_import = builtins.__import__
+
+    def fake_import(name: str, *args: Any, **kwargs: Any):
+        if name in names or name.split(".")[0] in names:
+            raise ImportError(name)
+        return real_import(name, *args, **kwargs)
+
+    return patch.object(builtins, "__import__", side_effect=fake_import)
+
+
+def test_render_returns_false_when_matplotlib_missing(tmp_path) -> None:
+    out = str(tmp_path / "n.png")
+    with _force_missing("matplotlib", "networkx"):
+        assert graph_image.render_neighborhood_png("u", "Root", [], [], out) is False
+
+
+def test_display_png_inline_false_when_term_image_missing(tmp_path) -> None:
+    png = tmp_path / "x.png"
+    png.write_bytes(b"not-really-a-png")
+    with _force_missing("term_image"):
+        assert graph_image.display_png_inline(str(png)) is False
+
+
+# --- try_inline_neighborhood (top-level fallback) ------------------------
+
+
+def test_try_inline_returns_false_when_terminal_unsupported() -> None:
+    nodes: List[dict] = [{"uuid": "a", "name": "A"}]
+    edges: List[dict] = [{"source": "u", "target": "a", "relation": "rel"}]
+    with patch.object(graph_image, "graphics_supported", return_value=False):
+        assert graph_image.try_inline_neighborhood("u", "Root", nodes, edges) is False
+
+
+def test_try_inline_returns_false_when_render_fails(tmp_path) -> None:
+    with patch.object(graph_image, "graphics_supported", return_value=True):
+        with patch.object(graph_image, "render_neighborhood_png", return_value=False):
+            assert graph_image.try_inline_neighborhood("u", "R", [], []) is False
+
+
+def test_try_inline_signals_displayed_when_everything_works() -> None:
+    with patch.object(graph_image, "graphics_supported", return_value=True):
+        with patch.object(graph_image, "render_neighborhood_png", return_value=True):
+            with patch.object(graph_image, "display_png_inline", return_value=True):
+                result = graph_image.try_inline_neighborhood("u", "R", [], [])
+    assert result is True

--- a/tests/unit/test_graph_parity.py
+++ b/tests/unit/test_graph_parity.py
@@ -1,0 +1,45 @@
+"""Parity test: every graph capability has both a client method and a CLI command.
+
+Pure introspection -- no network access. Guards against the client and the CLI
+drifting apart (a capability added to one but not the other).
+"""
+
+from apollo.cli.main import graph
+from apollo.client.hcg_query_client import HCGQueryClient
+
+# capability -> (client method name, CLI command name)
+_CAPABILITIES = {
+    "stats": ("stats", "stats"),
+    "types": ("types", "types"),
+    "neighborhood": ("neighborhood", "neighbors"),
+    "search": ("search", "search"),
+}
+
+
+def test_client_has_all_capability_methods() -> None:
+    """HCGQueryClient exposes a method for every graph capability."""
+    for capability, (method_name, _command) in _CAPABILITIES.items():
+        assert hasattr(
+            HCGQueryClient, method_name
+        ), f"HCGQueryClient missing method '{method_name}' for '{capability}'"
+        assert callable(getattr(HCGQueryClient, method_name))
+
+
+def test_graph_group_has_all_capability_commands() -> None:
+    """The graph CLI group exposes a command for every graph capability."""
+    command_names = set(graph.commands.keys())
+    for capability, (_method, command_name) in _CAPABILITIES.items():
+        assert (
+            command_name in command_names
+        ), f"graph group missing command '{command_name}' for '{capability}'"
+
+
+def test_graph_group_has_node_command() -> None:
+    """The entity lookup is exposed as the 'node' command."""
+    assert "node" in graph.commands
+
+
+def test_client_has_entity_method() -> None:
+    """The entity lookup capability exists on the client."""
+    assert hasattr(HCGQueryClient, "entity")
+    assert callable(HCGQueryClient.entity)

--- a/tests/unit/test_hcg_query_client.py
+++ b/tests/unit/test_hcg_query_client.py
@@ -1,0 +1,203 @@
+"""Unit tests for :class:`apollo.client.hcg_query_client.HCGQueryClient`.
+
+The client is a thin HTTP wrapper around Sophia's ``/hcg/*`` read API. These
+tests mock ``requests.get`` so they exercise the URL/params/header building,
+the JSON shape coercion (dict-vs-list defaults), and the error-wrapping paths
+without needing a live Sophia.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+
+from apollo.client.hcg_query_client import (
+    HCGQueryClient,
+    HCGQueryError,
+    _build_headers,
+    _normalize_base_url,
+)
+from apollo.config.settings import SophiaConfig
+
+
+def _client(api_key: Optional[str] = "tok") -> HCGQueryClient:
+    config = SophiaConfig(host="localhost", port=47000, timeout=5, api_key=api_key)
+    return HCGQueryClient(config)
+
+
+def _mock_response(
+    json_data: Any = None,
+    *,
+    status_code: int = 200,
+    raise_json: bool = False,
+    text: str = "",
+) -> Mock:
+    response = Mock()
+    response.status_code = status_code
+    response.text = text
+    response.raise_for_status = Mock()
+    if raise_json:
+        response.json = Mock(side_effect=ValueError("no json"))
+    else:
+        response.json = Mock(return_value=json_data)
+    return response
+
+
+# --- helpers -------------------------------------------------------------
+
+
+def test_normalize_base_url_from_host_port() -> None:
+    assert _normalize_base_url("localhost", 47000) == "http://localhost:47000"
+
+
+def test_normalize_base_url_honours_full_url() -> None:
+    assert _normalize_base_url("https://sophia.example/", 1) == "https://sophia.example"
+
+
+def test_build_headers_with_and_without_key() -> None:
+    assert _build_headers("abc")["Authorization"] == "Bearer abc"
+    assert "Authorization" not in _build_headers(None)
+    assert "Authorization" not in _build_headers("")
+
+
+def test_init_builds_base_url_and_headers() -> None:
+    client = _client("secret")
+    assert client.base_url == "http://localhost:47000"
+    assert client.timeout == 5
+    assert client._headers["Authorization"] == "Bearer secret"
+
+
+# --- happy paths ---------------------------------------------------------
+
+
+def test_stats_returns_dict() -> None:
+    client = _client()
+    payload: Dict[str, Any] = {"total_nodes": 10}
+    with patch("apollo.client.hcg_query_client.requests.get") as get:
+        get.return_value = _mock_response(payload)
+        assert client.stats() == payload
+        url = get.call_args.args[0]
+        assert url == "http://localhost:47000/hcg/stats"
+        assert get.call_args.kwargs["headers"]["Authorization"] == "Bearer tok"
+        assert get.call_args.kwargs["timeout"] == 5
+
+
+def test_stats_coerces_non_dict_to_empty() -> None:
+    client = _client()
+    with patch("apollo.client.hcg_query_client.requests.get") as get:
+        get.return_value = _mock_response([1, 2, 3])
+        assert client.stats() == {}
+
+
+def test_types_returns_list_and_passes_limit() -> None:
+    client = _client()
+    with patch("apollo.client.hcg_query_client.requests.get") as get:
+        get.return_value = _mock_response([{"name": "cell"}])
+        assert client.types(limit=42) == [{"name": "cell"}]
+        assert get.call_args.kwargs["params"] == {"limit": 42}
+
+
+def test_types_coerces_non_list_to_empty() -> None:
+    client = _client()
+    with patch("apollo.client.hcg_query_client.requests.get") as get:
+        get.return_value = _mock_response({"oops": True})
+        assert client.types() == []
+
+
+def test_neighborhood_builds_path_and_params() -> None:
+    client = _client()
+    with patch("apollo.client.hcg_query_client.requests.get") as get:
+        get.return_value = _mock_response({"nodes": [], "edges": []})
+        result = client.neighborhood("uuid-1", depth=2, limit=7)
+        assert result == {"nodes": [], "edges": []}
+        assert get.call_args.args[0].endswith("/hcg/neighborhood/uuid-1")
+        assert get.call_args.kwargs["params"] == {"depth": 2, "limit": 7}
+
+
+def test_neighborhood_coerces_non_dict_to_empty() -> None:
+    client = _client()
+    with patch("apollo.client.hcg_query_client.requests.get") as get:
+        get.return_value = _mock_response("not-a-dict")
+        assert client.neighborhood("u") == {}
+
+
+def test_search_returns_list_and_passes_query() -> None:
+    client = _client()
+    with patch("apollo.client.hcg_query_client.requests.get") as get:
+        get.return_value = _mock_response([{"uuid": "x"}])
+        assert client.search("cell", limit=3) == [{"uuid": "x"}]
+        assert get.call_args.kwargs["params"] == {"q": "cell", "limit": 3}
+        assert get.call_args.args[0].endswith("/hcg/search")
+
+
+def test_search_coerces_non_list_to_empty() -> None:
+    client = _client()
+    with patch("apollo.client.hcg_query_client.requests.get") as get:
+        get.return_value = _mock_response({"oops": True})
+        assert client.search("q") == []
+
+
+def test_entity_builds_path() -> None:
+    client = _client()
+    with patch("apollo.client.hcg_query_client.requests.get") as get:
+        get.return_value = _mock_response({"uuid": "e1", "name": "Cell"})
+        result = client.entity("e1")
+        assert result == {"uuid": "e1", "name": "Cell"}
+        assert get.call_args.args[0].endswith("/hcg/entities/e1")
+
+
+def test_entity_coerces_non_dict_to_empty() -> None:
+    client = _client()
+    with patch("apollo.client.hcg_query_client.requests.get") as get:
+        get.return_value = _mock_response(["not", "a", "dict"])
+        assert client.entity("e1") == {}
+
+
+# --- error wrapping ------------------------------------------------------
+
+
+def test_connection_error_wrapped() -> None:
+    client = _client()
+    with patch("apollo.client.hcg_query_client.requests.get") as get:
+        get.side_effect = requests.ConnectionError("refused")
+        with pytest.raises(HCGQueryError) as exc:
+            client.stats()
+        assert "Failed to reach Sophia HCG endpoint" in str(exc.value)
+
+
+def test_http_error_wrapped_with_snippet() -> None:
+    client = _client()
+    response = _mock_response(text="boom detail")
+    response.raise_for_status.side_effect = requests.HTTPError("500")
+    response.status_code = 500
+    with patch("apollo.client.hcg_query_client.requests.get") as get:
+        get.return_value = response
+        with pytest.raises(HCGQueryError) as exc:
+            client.stats()
+        message = str(exc.value)
+        assert "failed with status 500" in message
+        assert "boom detail" in message
+
+
+def test_http_error_truncates_long_snippet() -> None:
+    client = _client()
+    response = _mock_response(text="x" * 500)
+    response.raise_for_status.side_effect = requests.HTTPError("500")
+    response.status_code = 500
+    with patch("apollo.client.hcg_query_client.requests.get") as get:
+        get.return_value = response
+        with pytest.raises(HCGQueryError) as exc:
+            client.stats()
+        assert "..." in str(exc.value)
+
+
+def test_invalid_json_wrapped() -> None:
+    client = _client()
+    with patch("apollo.client.hcg_query_client.requests.get") as get:
+        get.return_value = _mock_response(raise_json=True)
+        with pytest.raises(HCGQueryError) as exc:
+            client.stats()
+        assert "was not valid JSON" in str(exc.value)


### PR DESCRIPTION
Part of #197. The basic graph tools you wanted in apollo-cli, asking **sophia** for the data (she gatekeeps Neo4j) with modern terminal visuals.

## Commands (`apollo-cli graph …`)
- **stats** — Panel + a content-vs-edge-node proportion bar + by-realm/top-predicate bars
- **types** — rich **Tree** of the positional hierarchy (`cell (49)` under `entity (1235)`…)
- **neighbors** — de-reified directional **Tree** (`─ABUNDANT_IN→ human body`); optional inline node-link **image** (`--image`) on kitty/iTerm2/sixel terminals, graceful Tree fallback otherwise
- **node** — Panel with syntax-highlighted YAML properties
- **search** — Table

## How it's wired
- `hcg_query_client.py` — thin `requests` client to sophia's `/hcg/*` (Bearer auth). **No Neo4j, no HCGClient import** — apollo asks the gatekeeper over the network.
- Inline-image deps (term-image/networkx/matplotlib/pillow) are gated behind a `graph-image` poetry extra so the base install stays lean.
- `SophiaConfig.api_key` now reads the canonical `SOPHIA_API_TOKEN`.

## Depends on
sophia#227 (the `/hcg/{stats,types,neighborhood,search}` endpoints) deployed.

## Verification
Live against sophia:47000 — stats panel, types tree, de-reified neighbors tree all render; image renders headlessly to a PNG and falls back cleanly. ruff/black/mypy clean; parity + config tests; cli_sdk regression green.

https://claude.ai/code/session_01YbGTE3BmHaRBNmJRZbF2oA