### PR TITLE
feat(explorer): lazy-load via scoped sophia endpoints (seed + expand)

### DIFF
--- a/webapp/src/__tests__/sophia-client.test.ts
+++ b/webapp/src/__tests__/sophia-client.test.ts
@@ -376,5 +376,123 @@ describe('SophiaClient', () => {
 
       expect(result).toBe(false)
     })
+
+    // --- Lazy-load (seed + expand) scoped endpoints ---
+
+    it('fetches HCG stats from /hcg/stats', async () => {
+      const statsResponse = {
+        total_nodes: 7006,
+        content_nodes: 2313,
+        edge_nodes: 4693,
+        type_definitions: 16,
+        content_classified: 965,
+        content_parked: 1311,
+        by_realm: { entity: 2109, process: 94 },
+        top_predicates: { IS_A: 2276 },
+      }
+      fetchMock.mockResolvedValueOnce(jsonResponse(statsResponse))
+
+      const result = await client.getHCGStats()
+
+      expect(result.success).toBe(true)
+      expect(result.data?.total_nodes).toBe(7006)
+      expect(result.data?.by_realm.entity).toBe(2109)
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://test-sophia:8080/hcg/stats',
+        expect.objectContaining({ method: 'GET' })
+      )
+    })
+
+    it('fetches the HCG type layer from /hcg/types with a limit', async () => {
+      const typesResponse = [
+        { uuid: 't-1', name: 'entity', member_count: 1235, parent: 'node' },
+        { uuid: 't-2', name: 'chemical substance', member_count: 78, parent: 'agent' },
+      ]
+      fetchMock.mockResolvedValueOnce(jsonResponse(typesResponse))
+
+      const result = await client.getHCGTypes(40)
+
+      expect(result.success).toBe(true)
+      expect(result.data).toHaveLength(2)
+      expect(result.data?.[0].member_count).toBe(1235)
+      const url = fetchMock.mock.calls[0][0] as string
+      expect(url).toContain('/hcg/types')
+      expect(url).toContain('limit=40')
+    })
+
+    it('fetches a de-reified neighborhood from /hcg/neighborhood/{uuid}', async () => {
+      const neighborhoodResponse = {
+        nodes: [
+          { uuid: 'n-1', name: 'social plant', type: 'entity', properties: {} },
+          { uuid: 'n-2', name: 'mutual aid', type: 'entity', properties: {} },
+        ],
+        edges: [
+          { id: 'e-1', source: 'n-1', target: 'n-2', relation: 'IS_A' },
+        ],
+        metadata: {
+          root: 'n-1',
+          depth: 1,
+          reified: false,
+          node_count: 2,
+          edge_count: 1,
+        },
+      }
+      fetchMock.mockResolvedValueOnce(jsonResponse(neighborhoodResponse))
+
+      const result = await client.getHCGNeighborhood('n-1', 1, 60)
+
+      expect(result.success).toBe(true)
+      expect(result.data?.nodes).toHaveLength(2)
+      expect(result.data?.edges[0].relation).toBe('IS_A')
+      expect(result.data?.metadata.reified).toBe(false)
+      const url = fetchMock.mock.calls[0][0] as string
+      expect(url).toContain('/hcg/neighborhood/n-1')
+      expect(url).toContain('depth=1')
+      expect(url).toContain('limit=60')
+    })
+
+    it('url-encodes the neighborhood uuid', async () => {
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({
+          nodes: [],
+          edges: [],
+          metadata: { root: 'a/b', depth: 1, reified: false, node_count: 0, edge_count: 0 },
+        })
+      )
+
+      await client.getHCGNeighborhood('a/b')
+
+      const url = fetchMock.mock.calls[0][0] as string
+      expect(url).toContain('/hcg/neighborhood/a%2Fb')
+    })
+
+    it('searches HCG nodes via /hcg/search', async () => {
+      const searchResponse = [
+        { uuid: 's-1', name: 'Plan: Blue Block to Bin', type: 'plan' },
+        { uuid: 's-2', name: 'social plant', type: 'entity' },
+      ]
+      fetchMock.mockResolvedValueOnce(jsonResponse(searchResponse))
+
+      const result = await client.searchHCG('plan', 20)
+
+      expect(result.success).toBe(true)
+      expect(result.data).toHaveLength(2)
+      expect(result.data?.[0].type).toBe('plan')
+      const url = fetchMock.mock.calls[0][0] as string
+      expect(url).toContain('/hcg/search')
+      expect(url).toContain('q=plan')
+      expect(url).toContain('limit=20')
+    })
+
+    it('surfaces a failed stats request as an error result', async () => {
+      fetchMock.mockResolvedValueOnce(
+        new Response('boom', { status: 500, statusText: 'Server Error' })
+      )
+
+      const result = await client.getHCGStats()
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBeTruthy()
+    })
   })
 })

--- a/webapp/src/components/hcg-explorer/HCGExplorer.css
+++ b/webapp/src/components/hcg-explorer/HCGExplorer.css
@@ -587,3 +587,162 @@
   padding: 2px 8px;
   font-size: 11px;
 }
+
+/* ---------------------------------------------------------------------------
+   Lazy-load (seed + expand) UI: seedbar, chips, seed results, empty state.
+   --------------------------------------------------------------------------- */
+
+.hcg-seedbar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  padding: 8px 16px;
+  background: var(--hcg-bg-secondary);
+  border-bottom: 1px solid var(--hcg-border);
+}
+
+.hcg-seedbar-stats,
+.hcg-seedbar-counts {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 12px;
+  color: var(--hcg-text-secondary);
+  white-space: nowrap;
+}
+
+.hcg-stat--muted {
+  opacity: 0.6;
+  font-style: italic;
+}
+
+.hcg-seedbar-search {
+  position: relative;
+  flex: 0 1 320px;
+  min-width: 200px;
+}
+
+.hcg-seedbar-search .hcg-input--search {
+  width: 100%;
+}
+
+.hcg-seed-results {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  z-index: 20;
+  max-height: 280px;
+  overflow-y: auto;
+  background: var(--hcg-bg-tertiary);
+  border: 1px solid var(--hcg-border);
+  border-radius: 6px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+}
+
+.hcg-seed-result {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 10px;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--hcg-border);
+  color: var(--hcg-text-primary);
+  font-size: 12px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.hcg-seed-result:last-child {
+  border-bottom: none;
+}
+
+.hcg-seed-result:hover {
+  background: rgba(99, 102, 241, 0.15);
+}
+
+.hcg-seed-result--muted {
+  color: var(--hcg-text-secondary);
+  cursor: default;
+}
+
+.hcg-seed-result-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hcg-seed-result-type {
+  flex: 0 0 auto;
+  font-size: 11px;
+  text-transform: lowercase;
+}
+
+.hcg-seedbar-chips {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.hcg-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 10px;
+  background: var(--hcg-bg-tertiary);
+  border: 1px solid var(--hcg-border);
+  border-radius: 999px;
+  color: var(--hcg-text-primary);
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.hcg-chip:hover {
+  background: rgba(99, 102, 241, 0.15);
+  border-color: var(--hcg-accent);
+}
+
+.hcg-chip-count {
+  font-size: 10px;
+  color: var(--hcg-text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+
+.hcg-mock-banner--error {
+  background: linear-gradient(90deg, #ef444433, #ef444422);
+  border-bottom: 1px solid #ef4444;
+}
+
+.hcg-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  height: 100%;
+  padding: 24px;
+  text-align: center;
+}
+
+.hcg-empty-title {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--hcg-text-primary);
+}
+
+.hcg-empty-hint {
+  max-width: 420px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--hcg-text-secondary);
+}
+
+.hcg-detail-expand {
+  width: 100%;
+  margin: 8px 0;
+}

--- a/webapp/src/components/hcg-explorer/HCGExplorer.tsx
+++ b/webapp/src/components/hcg-explorer/HCGExplorer.tsx
@@ -201,6 +201,7 @@ function HCGExplorerInner({
     data: neighborhood,
     isFetching: isExpanding,
     error: neighborhoodError,
+    refetch: refetchNeighborhood,
   } = useHCGNeighborhood(expandUuid, 1, 60)
 
   // Track the last neighborhood we merged so re-renders / refetches of an
@@ -218,6 +219,24 @@ function HCGExplorerInner({
     mergeNeighborhood(neighborhood, expandUuid)
   }, [neighborhood, expandUuid, mergeNeighborhood])
 
+  // Point the expand query at `uuid` and allow the next response to merge.
+  // If `uuid` is ALREADY the active target, setExpandUuid is a no-op (React
+  // bails on an identical value), so the fetch/merge would never re-fire --
+  // force a refetch instead. This is what makes "Re-expand neighborhood"
+  // actually re-fetch (and merge any new neighbors), and lets a failed expand
+  // be retried.
+  const triggerExpand = useCallback(
+    (uuid: string) => {
+      lastMergedKeyRef.current = null
+      if (uuid === expandUuid) {
+        void refetchNeighborhood()
+      } else {
+        setExpandUuid(uuid)
+      }
+    },
+    [expandUuid, refetchNeighborhood]
+  )
+
   // Seed the graph with a search result / type chip (plants the node + its
   // neighborhood). Seeding is an intentional "start exploring" action, so it
   // explicitly switches into lazy mode FIRST -- a full-graph view is never
@@ -225,11 +244,10 @@ function HCGExplorerInner({
   // flips to "Lazy mode" and the working-set counts appear).
   const handleSeed = useCallback(
     (uuid: string) => {
-      lastMergedKeyRef.current = null
       setDataMode('lazy')
-      setExpandUuid(uuid)
+      triggerExpand(uuid)
     },
-    [setDataMode]
+    [setDataMode, triggerExpand]
   )
 
   // Expand the currently selected node on demand. Only reachable from the
@@ -237,11 +255,10 @@ function HCGExplorerInner({
   // always what grows (never the abandoned full snapshot).
   const handleExpand = useCallback(
     (uuid: string) => {
-      lastMergedKeyRef.current = null
       setDataMode('lazy')
-      setExpandUuid(uuid)
+      triggerExpand(uuid)
     },
-    [setDataMode]
+    [setDataMode, triggerExpand]
   )
 
   // Clear the working set back to an empty canvas.

--- a/webapp/src/components/hcg-explorer/HCGExplorer.tsx
+++ b/webapp/src/components/hcg-explorer/HCGExplorer.tsx
@@ -6,7 +6,14 @@
  */
 
 import { useEffect, useMemo, useCallback, useState, useRef, type ChangeEvent } from 'react'
-import { useHCGSnapshot, type HCGGraphSnapshot } from '../../hooks/useHCG'
+import {
+  useHCGSnapshot,
+  useHCGStats,
+  useHCGTypes,
+  useHCGSearch,
+  useHCGNeighborhood,
+  type HCGGraphSnapshot,
+} from '../../hooks/useHCG'
 import { HCGExplorerProvider, useHCGExplorer } from './context'
 import { ThreeRenderer } from './renderers/ThreeRenderer'
 import { CytoscapeRenderer } from './renderers/CytoscapeRenderer'
@@ -123,12 +130,18 @@ function HCGExplorerInner({
     addSnapshot,
     setTimelineIndex,
     togglePlayback,
+    setDataMode,
+    mergeNeighborhood,
+    resetWorkingSet,
   } = useHCGExplorer()
 
   const {
     viewMode,
     layout,
     filterConfig,
+    dataMode,
+    workingSet,
+    expandedNodeIds,
     currentSnapshot,
     snapshotHistory,
     timelineIndex,
@@ -161,7 +174,79 @@ function HCGExplorerInner({
   // Passed to both renderers; changing a slider re-lays-out the canvas live.
   const [densityParams, setDensityParams] = useState<DensityParams>(DEFAULT_DENSITY)
 
-  // Fetch graph data
+  // ---------------------------------------------------------------------------
+  // Lazy-load (seed + expand): the canvas starts empty and grows a working set.
+  // ---------------------------------------------------------------------------
+
+  // Headline stats for the header (total nodes + typing coverage). Graceful:
+  // an error just leaves the header counts blank, it never blocks the canvas.
+  const { data: stats } = useHCGStats()
+
+  // Positional type layer for entry chips.
+  const { data: typeLayer } = useHCGTypes(40)
+
+  // Seed search box. The enabled-guard in useHCGSearch doubles as a debounce:
+  // an empty box issues no request.
+  const [seedQuery, setSeedQuery] = useState('')
+  const {
+    data: searchResults,
+    isFetching: isSearching,
+    error: searchError,
+  } = useHCGSearch(seedQuery)
+
+  // Expand target: the uuid whose neighborhood we want to fetch + merge next.
+  // Set by seeding a search result, clicking a type chip, or expanding a node.
+  const [expandUuid, setExpandUuid] = useState<string | null>(null)
+  const {
+    data: neighborhood,
+    isFetching: isExpanding,
+    error: neighborhoodError,
+  } = useHCGNeighborhood(expandUuid, 1, 60)
+
+  // Track the last neighborhood we merged so re-renders / refetches of an
+  // identical response don't re-dispatch a merge (the metadata.root + counts
+  // form a stable key for one fetch result).
+  const lastMergedKeyRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (!neighborhood || !expandUuid) return
+    const key = `${neighborhood.metadata.root}:${neighborhood.metadata.node_count}:${neighborhood.metadata.edge_count}`
+    if (key === lastMergedKeyRef.current) return
+    lastMergedKeyRef.current = key
+    mergeNeighborhood(neighborhood, expandUuid)
+  }, [neighborhood, expandUuid, mergeNeighborhood])
+
+  // Seed the graph with a search result (plants the node + its neighborhood).
+  const handleSeed = useCallback(
+    (uuid: string) => {
+      lastMergedKeyRef.current = null
+      setExpandUuid(uuid)
+    },
+    []
+  )
+
+  // Expand the currently selected (or any) node on demand.
+  const handleExpand = useCallback(
+    (uuid: string) => {
+      lastMergedKeyRef.current = null
+      setExpandUuid(uuid)
+    },
+    []
+  )
+
+  // Clear the working set back to an empty canvas.
+  const handleResetWorkingSet = useCallback(() => {
+    lastMergedKeyRef.current = null
+    setExpandUuid(null)
+    setSeedQuery('')
+    resetWorkingSet()
+  }, [resetWorkingSet])
+
+  // ---------------------------------------------------------------------------
+  // Full-snapshot path (legacy / small graphs), behind "Load full graph".
+  // The query only fires once the user opts in (dataMode === 'full'), so the
+  // default lazy mode never pulls the whole graph.
+  // ---------------------------------------------------------------------------
+  const fullMode = dataMode === 'full'
   const {
     data: apiSnapshot,
     isLoading,
@@ -175,7 +260,8 @@ function HCGExplorerInner({
     // high limit explicitly so the shared hook's default stays small for other
     // callers (e.g. GraphViewer) (greptile #186).
     limit: 10000,
-    refetchInterval: refreshInterval > 0 ? refreshInterval : false,
+    refetchInterval: fullMode && refreshInterval > 0 ? refreshInterval : false,
+    enabled: fullMode,
   })
 
   // Track whether we've loaded any data (for mock fallback decision).
@@ -188,8 +274,12 @@ function HCGExplorerInner({
   // unchanged. Without this guard every poll rebuilt the whole pipeline.
   const lastSnapshotFpRef = useRef<string | null>(null)
 
-  // Add new snapshots to history (with mock fallback)
+  // Add new snapshots to history (with mock fallback). Full-snapshot path only:
+  // in lazy mode the canvas is driven by the working set, never by a snapshot,
+  // and there is no mock fallback (an empty canvas with a seed prompt is the
+  // correct empty state).
   useEffect(() => {
+    if (!fullMode) return
     if (apiSnapshot) {
       setUsingMockData(false)
       hasDataRef.current = true
@@ -206,20 +296,32 @@ function HCGExplorerInner({
       hasDataRef.current = true
       addSnapshot(generateMockSnapshot())
     }
-  }, [apiSnapshot, error, addSnapshot])
+  }, [fullMode, apiSnapshot, error, addSnapshot])
+
+  // The snapshot the canvas + panels operate on: the accumulated lazy-load
+  // working set by default, or the full snapshot once "Load full graph" is on.
+  // workingSet is always a (possibly empty) snapshot, so lazy mode has data as
+  // soon as the first seed merges.
+  const activeSnapshot: GraphSnapshot | null = fullMode ? currentSnapshot : workingSet
+  const hasGraph = !!activeSnapshot && activeSnapshot.entities.length > 0
 
   // Process graph data for rendering. The chosen view (logical vs reified) is
-  // applied by buildGraph; see graph-processor for the two transforms.
+  // applied by buildGraph; see graph-processor for the two transforms. Expanded
+  // node ids are threaded so explored nodes are marked in lazy mode.
+  const expandedIdSet = useMemo<Set<string>>(
+    () => new Set(expandedNodeIds),
+    [expandedNodeIds]
+  )
   const processedGraph = useMemo<ProcessedGraph>(() => {
-    if (!currentSnapshot) {
+    if (!activeSnapshot) {
       return { nodes: [], edges: [], clusters: [] }
     }
-    return buildGraph(currentSnapshot, graphMode, filterConfig)
-  }, [currentSnapshot, filterConfig, graphMode])
+    return buildGraph(activeSnapshot, graphMode, filterConfig, expandedIdSet)
+  }, [activeSnapshot, filterConfig, graphMode, expandedIdSet])
 
   // Derive entity types from the rendered graph, ordered by known types first.
   const entityTypes = useMemo<string[]>(() => {
-    if (!currentSnapshot) return KNOWN_ENTITY_TYPES
+    if (!activeSnapshot) return KNOWN_ENTITY_TYPES
     // Reflect ALL types present in the current view, independent of the active
     // search / status / property filters — otherwise the type buttons vanish as
     // you type a search. This used to run a SECOND full buildGraph() (transform
@@ -230,22 +332,22 @@ function HCGExplorerInner({
     // one 'edge' node type. That is an O(N) pass with no graph rebuild.
     const isReified = graphMode === 'reified'
     const seen = new Set<string>()
-    for (const e of currentSnapshot.entities) {
+    for (const e of activeSnapshot.entities) {
       if (isReified || !isEdgeTypeDef(e)) seen.add(e.type)
     }
-    if (isReified && currentSnapshot.edges.length > 0) seen.add('edge')
+    if (isReified && activeSnapshot.edges.length > 0) seen.add('edge')
     const ordered = KNOWN_ENTITY_TYPES.filter(t => seen.has(t))
     for (const t of seen) {
       if (!ordered.includes(t)) ordered.push(t)
     }
     return ordered
-  }, [currentSnapshot, graphMode])
+  }, [activeSnapshot, graphMode])
 
   // Flat, IS_A-driven type list for the Types panel. Counts come from IS_A
   // edges (deriveTypeSummaries), independent of the realm-based entityTypes.
   const typeSummaries = useMemo<TypeSummary[]>(
-    () => (currentSnapshot ? deriveTypeSummaries(currentSnapshot) : []),
-    [currentSnapshot]
+    () => (activeSnapshot ? deriveTypeSummaries(activeSnapshot) : []),
+    [activeSnapshot]
   )
 
   // Local text filter for the Types list (filters the rows, not the graph).
@@ -306,21 +408,21 @@ function HCGExplorerInner({
   // context. Null when nothing is focused (no dimming). This is the default
   // interaction; the restrict-style hard filter lives behind the selection mode.
   const highlightedNodeIds = useMemo<Set<string> | null>(() => {
-    if (!currentSnapshot) return null
+    if (!activeSnapshot) return null
     // Restrict mode already hard-filters the graph to the selection in
     // buildGraph; dimming on top of that is redundant for a selected type and
     // wrongly dims the whole graph when a single node is clicked. Dimming is the
     // highlight-mode affordance only.
     if (filterConfig.selectionMode === 'restrict') return null
     if (filterConfig.selectedTypeId) {
-      return computeTypeMemberIds(currentSnapshot, filterConfig.selectedTypeId)
+      return computeTypeMemberIds(activeSnapshot, filterConfig.selectedTypeId)
     }
     if (selectedNodeId) {
-      return computeHighlightSubgraphIds(currentSnapshot, selectedNodeId)
+      return computeHighlightSubgraphIds(activeSnapshot, selectedNodeId)
     }
     return null
   }, [
-    currentSnapshot,
+    activeSnapshot,
     filterConfig.selectedTypeId,
     filterConfig.selectionMode,
     selectedNodeId,
@@ -331,13 +433,13 @@ function HCGExplorerInner({
   // node is framed. Independent of selectionMode (unlike highlightedNodeIds) so
   // framing works in both highlight and restrict.
   const focusNodeIds = useMemo<Set<string> | null>(() => {
-    if (!currentSnapshot) return null
+    if (!activeSnapshot) return null
     if (filterConfig.selectedTypeId) {
-      return computeTypeMemberIds(currentSnapshot, filterConfig.selectedTypeId)
+      return computeTypeMemberIds(activeSnapshot, filterConfig.selectedTypeId)
     }
     if (selectedNodeId) return new Set([selectedNodeId])
     return null
-  }, [currentSnapshot, filterConfig.selectedTypeId, selectedNodeId])
+  }, [activeSnapshot, filterConfig.selectedTypeId, selectedNodeId])
 
   // Handle view mode change
   const handleViewModeChange = useCallback(
@@ -415,6 +517,128 @@ function HCGExplorerInner({
 
   return (
     <div className={`hcg-explorer ${className}`}>
+      {/* Seed / lazy-load bar: stats header, seed search, type chips, mode +
+          reset. The canvas starts empty; seeding a node (or a type chip)
+          plants its neighborhood, and Expand grows the working set on demand. */}
+      <div className="hcg-seedbar">
+        {/* Stats header (typing coverage). Blank if /hcg/stats errored. */}
+        <div className="hcg-seedbar-stats">
+          {stats ? (
+            <>
+              <span className="hcg-stat" title="Total nodes in the graph">
+                {stats.total_nodes.toLocaleString()} nodes
+              </span>
+              <span className="hcg-stat" title="Content nodes that have been typed">
+                {stats.content_classified.toLocaleString()}/
+                {stats.content_nodes.toLocaleString()} typed
+              </span>
+              <span className="hcg-stat" title="Type-definition nodes">
+                {stats.type_definitions} types
+              </span>
+            </>
+          ) : (
+            <span className="hcg-stat hcg-stat--muted">graph stats unavailable</span>
+          )}
+        </div>
+
+        {/* Seed search */}
+        <div className="hcg-seedbar-search">
+          <input
+            type="text"
+            className="hcg-input hcg-input--search"
+            placeholder="Seed: search a node to plant on the canvas..."
+            value={seedQuery}
+            onChange={e => setSeedQuery(e.target.value)}
+          />
+          {seedQuery.trim() && (
+            <div className="hcg-seed-results">
+              {isSearching && (
+                <div className="hcg-seed-result hcg-seed-result--muted">Searching...</div>
+              )}
+              {!isSearching && searchResults && searchResults.length === 0 && (
+                <div className="hcg-seed-result hcg-seed-result--muted">No matches</div>
+              )}
+              {!isSearching &&
+                searchResults?.slice(0, 12).map(r => (
+                  <button
+                    key={r.uuid}
+                    className="hcg-seed-result"
+                    onClick={() => {
+                      handleSeed(r.uuid)
+                      setSeedQuery('')
+                    }}
+                    title={r.uuid}
+                  >
+                    <span className="hcg-seed-result-name">{r.name || r.uuid}</span>
+                    <span
+                      className="hcg-seed-result-type"
+                      style={{ color: NODE_COLORS[r.type] || NODE_COLORS.default }}
+                    >
+                      {r.type}
+                    </span>
+                  </button>
+                ))}
+            </div>
+          )}
+        </div>
+
+        {/* Type chips (entry points) */}
+        {typeLayer && typeLayer.length > 0 && (
+          <div className="hcg-seedbar-chips">
+            {typeLayer.slice(0, 12).map(t => (
+              <button
+                key={t.uuid}
+                className="hcg-chip"
+                onClick={() => handleSeed(t.uuid)}
+                title={`${t.name} — ${t.member_count} members`}
+              >
+                {t.name}
+                <span className="hcg-chip-count">{t.member_count}</span>
+              </button>
+            ))}
+          </div>
+        )}
+
+        <div style={{ flex: 1 }} />
+
+        {/* Working-set counts (lazy mode) */}
+        {!fullMode && (
+          <div className="hcg-seedbar-counts">
+            <span className="hcg-stat" title="Nodes in the working set">
+              {workingSet.entities.length} nodes
+            </span>
+            <span className="hcg-stat" title="Edges in the working set">
+              {workingSet.edges.length} edges
+            </span>
+            {isExpanding && <span className="hcg-stat hcg-stat--muted">expanding...</span>}
+          </div>
+        )}
+
+        {/* Reset (clear working set) */}
+        {!fullMode && hasGraph && (
+          <button
+            className="hcg-btn"
+            onClick={handleResetWorkingSet}
+            title="Clear the canvas back to empty"
+          >
+            Reset
+          </button>
+        )}
+
+        {/* Data-mode toggle: lazy (seed+expand) vs full snapshot. */}
+        <button
+          className={`hcg-btn ${fullMode ? 'hcg-btn--active' : ''}`}
+          onClick={() => setDataMode(fullMode ? 'lazy' : 'full')}
+          title={
+            fullMode
+              ? 'Switch back to lazy seed + expand'
+              : 'Load the entire graph snapshot (small graphs / back-compat)'
+          }
+        >
+          {fullMode ? 'Lazy mode' : 'Load full graph'}
+        </button>
+      </div>
+
       {/* Toolbar */}
       <div className="hcg-toolbar">
         {/* View Mode Toggle */}
@@ -542,17 +766,28 @@ function HCGExplorerInner({
         </div>
       )}
 
+      {/* Lazy-load expand/search error toast (never blocks the canvas) */}
+      {!fullMode && (neighborhoodError || searchError) && (
+        <div className="hcg-mock-banner hcg-mock-banner--error">
+          {neighborhoodError
+            ? `Couldn't expand that node: ${neighborhoodError.message}`
+            : `Search failed: ${searchError?.message}`}
+        </div>
+      )}
+
       {/* Main Content */}
       <div className="hcg-content">
         {/* Canvas */}
         <div className="hcg-canvas">
-          {isLoading && !currentSnapshot && (
+          {/* Full-mode loading */}
+          {fullMode && isLoading && !currentSnapshot && (
             <div className="hcg-loading">
               <div className="hcg-loading-spinner" />
             </div>
           )}
 
-          {error && !currentSnapshot && !usingMockData && (
+          {/* Full-mode error */}
+          {fullMode && error && !currentSnapshot && !usingMockData && (
             <div className="hcg-error">
               <div className="hcg-error-icon">!</div>
               <div className="hcg-error-message">
@@ -564,7 +799,19 @@ function HCGExplorerInner({
             </div>
           )}
 
-          {currentSnapshot && viewMode === '3d' && (
+          {/* Lazy-mode empty state: seed the graph from the search box. */}
+          {!fullMode && !hasGraph && (
+            <div className="hcg-empty">
+              <div className="hcg-empty-title">Explore the graph</div>
+              <div className="hcg-empty-hint">
+                {isExpanding
+                  ? 'Loading neighborhood...'
+                  : 'Search for a node above and click a result to seed the canvas, or pick a type chip. Click a node and Expand to grow the view.'}
+              </div>
+            </div>
+          )}
+
+          {hasGraph && viewMode === '3d' && (
             <ThreeRenderer
               graph={processedGraph}
               selectedNodeId={selectedNodeId}
@@ -578,7 +825,7 @@ function HCGExplorerInner({
             />
           )}
 
-          {currentSnapshot && viewMode === '2d' && (
+          {hasGraph && viewMode === '2d' && (
             <CytoscapeRenderer
               graph={processedGraph}
               selectedNodeId={selectedNodeId}
@@ -749,13 +996,29 @@ function HCGExplorerInner({
                         </span>
                       </div>
                     )}
+                    {!fullMode && (
+                      <button
+                        className="hcg-btn hcg-detail-expand"
+                        onClick={() => handleExpand(selectedNode.id)}
+                        disabled={isExpanding}
+                        title="Fetch this node's neighborhood and merge it into the canvas"
+                      >
+                        {expandedIdSet.has(selectedNode.id)
+                          ? 'Re-expand neighborhood'
+                          : isExpanding
+                            ? 'Expanding...'
+                            : 'Expand neighborhood'}
+                      </button>
+                    )}
                     <div className="hcg-properties">
                       {JSON.stringify(selectedNode.properties, null, 2)}
                     </div>
                   </div>
                 ) : (
                   <div className="hcg-node-details-empty">
-                    Click a node to view details
+                    {fullMode
+                      ? 'Click a node to view details'
+                      : 'Click a node to view details, then Expand to grow the view'}
                   </div>
                 )}
               </div>
@@ -909,11 +1172,11 @@ function HCGExplorerInner({
             {timelineIndex + 1} / {snapshotHistory.length}
           </span>
         </div>
-        {currentSnapshot?.timestamp && (
+        {activeSnapshot?.timestamp && (
           <div className="hcg-stat">
             <span>Updated:</span>
             <span className="hcg-stat-value">
-              {formatTime(currentSnapshot.timestamp)}
+              {formatTime(activeSnapshot.timestamp)}
             </span>
           </div>
         )}

--- a/webapp/src/components/hcg-explorer/HCGExplorer.tsx
+++ b/webapp/src/components/hcg-explorer/HCGExplorer.tsx
@@ -208,29 +208,40 @@ function HCGExplorerInner({
   // form a stable key for one fetch result).
   const lastMergedKeyRef = useRef<string | null>(null)
   useEffect(() => {
-    if (!neighborhood || !expandUuid) return
-    const key = `${neighborhood.metadata.root}:${neighborhood.metadata.node_count}:${neighborhood.metadata.edge_count}`
+    // Guard the whole metadata block: a malformed response missing `metadata`
+    // must not crash the merge effect (it just skips this render).
+    if (!neighborhood || !neighborhood.metadata || !expandUuid) return
+    const { root, node_count, edge_count } = neighborhood.metadata
+    const key = `${root}:${node_count}:${edge_count}`
     if (key === lastMergedKeyRef.current) return
     lastMergedKeyRef.current = key
     mergeNeighborhood(neighborhood, expandUuid)
   }, [neighborhood, expandUuid, mergeNeighborhood])
 
-  // Seed the graph with a search result (plants the node + its neighborhood).
+  // Seed the graph with a search result / type chip (plants the node + its
+  // neighborhood). Seeding is an intentional "start exploring" action, so it
+  // explicitly switches into lazy mode FIRST -- a full-graph view is never
+  // silently replaced by a merge (the mode flip is visible: the toolbar button
+  // flips to "Lazy mode" and the working-set counts appear).
   const handleSeed = useCallback(
     (uuid: string) => {
       lastMergedKeyRef.current = null
+      setDataMode('lazy')
       setExpandUuid(uuid)
     },
-    []
+    [setDataMode]
   )
 
-  // Expand the currently selected (or any) node on demand.
+  // Expand the currently selected node on demand. Only reachable from the
+  // lazy-mode detail panel, but switch explicitly too so the working set is
+  // always what grows (never the abandoned full snapshot).
   const handleExpand = useCallback(
     (uuid: string) => {
       lastMergedKeyRef.current = null
+      setDataMode('lazy')
       setExpandUuid(uuid)
     },
-    []
+    [setDataMode]
   )
 
   // Clear the working set back to an empty canvas.
@@ -526,14 +537,14 @@ function HCGExplorerInner({
           {stats ? (
             <>
               <span className="hcg-stat" title="Total nodes in the graph">
-                {stats.total_nodes.toLocaleString()} nodes
+                {(stats.total_nodes ?? 0).toLocaleString()} nodes
               </span>
               <span className="hcg-stat" title="Content nodes that have been typed">
-                {stats.content_classified.toLocaleString()}/
-                {stats.content_nodes.toLocaleString()} typed
+                {(stats.content_classified ?? 0).toLocaleString()}/
+                {(stats.content_nodes ?? 0).toLocaleString()} typed
               </span>
               <span className="hcg-stat" title="Type-definition nodes">
-                {stats.type_definitions} types
+                {stats.type_definitions ?? 0} types
               </span>
             </>
           ) : (
@@ -605,10 +616,10 @@ function HCGExplorerInner({
         {!fullMode && (
           <div className="hcg-seedbar-counts">
             <span className="hcg-stat" title="Nodes in the working set">
-              {workingSet.entities.length} nodes
+              {workingSet?.entities?.length ?? 0} nodes
             </span>
             <span className="hcg-stat" title="Edges in the working set">
-              {workingSet.edges.length} edges
+              {workingSet?.edges?.length ?? 0} edges
             </span>
             {isExpanding && <span className="hcg-stat hcg-stat--muted">expanding...</span>}
           </div>

--- a/webapp/src/components/hcg-explorer/context.test.tsx
+++ b/webapp/src/components/hcg-explorer/context.test.tsx
@@ -134,4 +134,29 @@ describe('HCGExplorer context — lazy-load reducer', () => {
     expect(result.current.state.dataMode).toBe('full')
     expect(result.current.state.workingSet.entities).toHaveLength(1)
   })
+
+  it('merging does NOT silently flip dataMode away from full (greptile P1)', () => {
+    // Regression guard: a user in full mode whose seed/expand merges a
+    // neighborhood must not have their dataMode silently changed by the
+    // reducer. The component owns the lazy transition (via setDataMode) so the
+    // switch is explicit; the reducer itself never flips the mode.
+    const { result } = renderHook(() => useHCGExplorer(), { wrapper })
+
+    act(() => {
+      result.current.setDataMode('full')
+    })
+    expect(result.current.state.dataMode).toBe('full')
+
+    act(() => {
+      result.current.mergeNeighborhood(
+        neighborhood([{ uuid: 'a', name: 'A', type: 'entity', properties: {} }], []),
+        'a'
+      )
+    })
+
+    // Mode is unchanged by the merge; only the working set + expanded ids grew.
+    expect(result.current.state.dataMode).toBe('full')
+    expect(result.current.state.workingSet.entities).toHaveLength(1)
+    expect(result.current.state.expandedNodeIds).toEqual(['a'])
+  })
 })

--- a/webapp/src/components/hcg-explorer/context.test.tsx
+++ b/webapp/src/components/hcg-explorer/context.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * Tests for the HCG Explorer state context, focused on the lazy-load
+ * (seed + expand) working-set reducer behaviour.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { HCGExplorerProvider, useHCGExplorer } from './context'
+import type { NeighborhoodPayload } from './types'
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <HCGExplorerProvider>{children}</HCGExplorerProvider>
+)
+
+const neighborhood = (
+  nodes: NeighborhoodPayload['nodes'],
+  edges: NeighborhoodPayload['edges']
+): NeighborhoodPayload => ({ nodes, edges })
+
+describe('HCGExplorer context — lazy-load reducer', () => {
+  it('starts in lazy mode with an empty working set', () => {
+    const { result } = renderHook(() => useHCGExplorer(), { wrapper })
+    expect(result.current.state.dataMode).toBe('lazy')
+    expect(result.current.state.workingSet.entities).toHaveLength(0)
+    expect(result.current.state.workingSet.edges).toHaveLength(0)
+    expect(result.current.state.expandedNodeIds).toHaveLength(0)
+  })
+
+  it('seeds the working set and marks the root expanded', () => {
+    const { result } = renderHook(() => useHCGExplorer(), { wrapper })
+
+    act(() => {
+      result.current.mergeNeighborhood(
+        neighborhood(
+          [
+            { uuid: 'a', name: 'A', type: 'entity', properties: {} },
+            { uuid: 'b', name: 'B', type: 'concept', properties: {} },
+          ],
+          [{ id: 'e1', source: 'a', target: 'b', relation: 'IS_A' }]
+        ),
+        'a'
+      )
+    })
+
+    expect(result.current.state.dataMode).toBe('lazy')
+    expect(result.current.state.workingSet.entities).toHaveLength(2)
+    expect(result.current.state.workingSet.edges).toHaveLength(1)
+    expect(result.current.state.expandedNodeIds).toEqual(['a'])
+  })
+
+  it('merges a second neighborhood with dedupe and accumulates expanded ids', () => {
+    const { result } = renderHook(() => useHCGExplorer(), { wrapper })
+
+    act(() => {
+      result.current.mergeNeighborhood(
+        neighborhood([{ uuid: 'a', name: 'A', type: 'entity', properties: {} }], []),
+        'a'
+      )
+    })
+    act(() => {
+      result.current.mergeNeighborhood(
+        neighborhood(
+          [
+            { uuid: 'a', name: 'A', type: 'entity', properties: {} },
+            { uuid: 'c', name: 'C', type: 'entity', properties: {} },
+          ],
+          [{ id: 'e2', source: 'a', target: 'c', relation: 'RELATED_TO' }]
+        ),
+        'c'
+      )
+    })
+
+    expect(
+      result.current.state.workingSet.entities.map(e => e.id).sort()
+    ).toEqual(['a', 'c'])
+    expect(result.current.state.workingSet.edges).toHaveLength(1)
+    expect(result.current.state.expandedNodeIds).toEqual(['a', 'c'])
+  })
+
+  it('does not duplicate an expanded id when the same root is re-expanded', () => {
+    const { result } = renderHook(() => useHCGExplorer(), { wrapper })
+
+    act(() => {
+      result.current.mergeNeighborhood(
+        neighborhood([{ uuid: 'a', name: 'A', type: 'entity', properties: {} }], []),
+        'a'
+      )
+    })
+    act(() => {
+      result.current.mergeNeighborhood(
+        neighborhood([{ uuid: 'a', name: 'A', type: 'entity', properties: {} }], []),
+        'a'
+      )
+    })
+
+    expect(result.current.state.expandedNodeIds).toEqual(['a'])
+  })
+
+  it('resets the working set back to empty', () => {
+    const { result } = renderHook(() => useHCGExplorer(), { wrapper })
+
+    act(() => {
+      result.current.mergeNeighborhood(
+        neighborhood([{ uuid: 'a', name: 'A', type: 'entity', properties: {} }], []),
+        'a'
+      )
+      result.current.selectNode('a')
+    })
+    expect(result.current.state.workingSet.entities).toHaveLength(1)
+
+    act(() => {
+      result.current.resetWorkingSet()
+    })
+
+    expect(result.current.state.workingSet.entities).toHaveLength(0)
+    expect(result.current.state.expandedNodeIds).toHaveLength(0)
+    expect(result.current.state.selectedNodeId).toBeNull()
+  })
+
+  it('switches data mode without touching the working set', () => {
+    const { result } = renderHook(() => useHCGExplorer(), { wrapper })
+
+    act(() => {
+      result.current.mergeNeighborhood(
+        neighborhood([{ uuid: 'a', name: 'A', type: 'entity', properties: {} }], []),
+        'a'
+      )
+    })
+    act(() => {
+      result.current.setDataMode('full')
+    })
+
+    expect(result.current.state.dataMode).toBe('full')
+    expect(result.current.state.workingSet.entities).toHaveLength(1)
+  })
+})

--- a/webapp/src/components/hcg-explorer/context.tsx
+++ b/webapp/src/components/hcg-explorer/context.tsx
@@ -137,15 +137,18 @@ function explorerReducer(
 
     case 'MERGE_NEIGHBORHOOD': {
       // Merge the fetched neighborhood into the accumulated working set
-      // (pure dedupe by node id / edge id). Mark the expanded root so the
-      // renderers can flag explored nodes. Switching to lazy mode here keeps
-      // the canvas pointed at the working set after a seed/expand.
+      // (pure dedupe by node id / edge id) and mark the expanded root so the
+      // renderers can flag explored nodes. Mode transitions are intentionally
+      // NOT performed here: this reducer never flips dataMode, so seeding while
+      // in 'full' mode can't silently replace the full graph. The component
+      // owns the lazy transition (via SET_DATA_MODE) before dispatching a seed
+      // so the switch is explicit and visible to the user.
       const workingSet = mergeNeighborhood(state.workingSet, action.neighborhood)
       const expandedNodeIds =
         action.rootId && !state.expandedNodeIds.includes(action.rootId)
           ? [...state.expandedNodeIds, action.rootId]
           : state.expandedNodeIds
-      return { ...state, dataMode: 'lazy', workingSet, expandedNodeIds }
+      return { ...state, workingSet, expandedNodeIds }
     }
 
     case 'RESET_WORKING_SET':

--- a/webapp/src/components/hcg-explorer/context.tsx
+++ b/webapp/src/components/hcg-explorer/context.tsx
@@ -19,11 +19,15 @@ import type {
   EmbeddingConfig,
   GraphSnapshot,
   TimestampedSnapshot,
+  DataMode,
+  NeighborhoodPayload,
 } from './types'
 import {
   DEFAULT_FILTER_CONFIG,
   DEFAULT_EMBEDDING_CONFIG,
+  EMPTY_SNAPSHOT,
 } from './types'
+import { mergeNeighborhood } from './utils/graph-processor'
 
 const HISTORY_LIMIT = 50
 
@@ -31,6 +35,10 @@ const HISTORY_LIMIT = 50
 const initialState: HCGExplorerState = {
   viewMode: '3d',
   layout: 'force-3d',
+  // Lazy seed+expand is the default; the canvas starts empty.
+  dataMode: 'lazy',
+  workingSet: EMPTY_SNAPSHOT,
+  expandedNodeIds: [],
   currentSnapshot: null,
   snapshotHistory: [],
   timelineIndex: -1,
@@ -124,6 +132,31 @@ function explorerReducer(
     case 'TOGGLE_CLUSTER_LEGEND':
       return { ...state, showClusterLegend: !state.showClusterLegend }
 
+    case 'SET_DATA_MODE':
+      return { ...state, dataMode: action.mode }
+
+    case 'MERGE_NEIGHBORHOOD': {
+      // Merge the fetched neighborhood into the accumulated working set
+      // (pure dedupe by node id / edge id). Mark the expanded root so the
+      // renderers can flag explored nodes. Switching to lazy mode here keeps
+      // the canvas pointed at the working set after a seed/expand.
+      const workingSet = mergeNeighborhood(state.workingSet, action.neighborhood)
+      const expandedNodeIds =
+        action.rootId && !state.expandedNodeIds.includes(action.rootId)
+          ? [...state.expandedNodeIds, action.rootId]
+          : state.expandedNodeIds
+      return { ...state, dataMode: 'lazy', workingSet, expandedNodeIds }
+    }
+
+    case 'RESET_WORKING_SET':
+      return {
+        ...state,
+        workingSet: EMPTY_SNAPSHOT,
+        expandedNodeIds: [],
+        selectedNodeId: null,
+        hoveredNodeId: null,
+      }
+
     default:
       return state
   }
@@ -145,6 +178,13 @@ interface HCGExplorerContextValue {
   setPlaybackSpeed: (speed: number) => void
   addSnapshot: (snapshot: GraphSnapshot) => void
   setEmbeddingConfig: (config: Partial<EmbeddingConfig>) => void
+  // Lazy-load (seed + expand)
+  setDataMode: (mode: DataMode) => void
+  mergeNeighborhood: (
+    neighborhood: NeighborhoodPayload,
+    rootId?: string | null
+  ) => void
+  resetWorkingSet: () => void
 }
 
 const HCGExplorerContext = createContext<HCGExplorerContextValue | null>(null)
@@ -174,6 +214,12 @@ export function HCGExplorerProvider({ children }: { children: ReactNode }) {
         dispatch({ type: 'ADD_SNAPSHOT', snapshot }),
       setEmbeddingConfig: (config: Partial<EmbeddingConfig>) =>
         dispatch({ type: 'SET_EMBEDDING_CONFIG', config }),
+      setDataMode: (mode: DataMode) => dispatch({ type: 'SET_DATA_MODE', mode }),
+      mergeNeighborhood: (
+        neighborhood: NeighborhoodPayload,
+        rootId?: string | null
+      ) => dispatch({ type: 'MERGE_NEIGHBORHOOD', neighborhood, rootId }),
+      resetWorkingSet: () => dispatch({ type: 'RESET_WORKING_SET' }),
     }),
     [dispatch]
   )

--- a/webapp/src/components/hcg-explorer/types.ts
+++ b/webapp/src/components/hcg-explorer/types.ts
@@ -41,6 +41,13 @@ export interface GraphNode {
   }
   embedding?: number[]
   clusterId?: string
+  /**
+   * True when this node has been expanded in the lazy-load explorer (its
+   * neighborhood has been fetched and merged into the working set). Renderers
+   * mark expanded nodes so the user can see what's already been explored.
+   * Absent / false for the full-snapshot path and existing fixtures.
+   */
+  expanded?: boolean
   properties: Record<string, unknown>
   raw: Entity
 }
@@ -145,13 +152,34 @@ export interface EmbeddingConfig {
   targetDimensions: 2 | 3
 }
 
+/**
+ * How the explorer is sourcing graph data.
+ * - 'lazy' (default): start empty, grow an accumulated working set via
+ *   seed (search) + expand (neighborhood). Scales to huge graphs.
+ * - 'full': the legacy whole-graph snapshot path, behind an explicit
+ *   "Load full graph" affordance (small graphs / back-compat).
+ */
+export type DataMode = 'lazy' | 'full'
+
 /** Explorer state */
 export interface HCGExplorerState {
   // View
   viewMode: ViewMode
   layout: LayoutType
 
-  // Data
+  // Data sourcing mode (lazy seed+expand vs full snapshot)
+  dataMode: DataMode
+
+  /**
+   * Accumulated lazy-load working set: the union of every seeded/expanded
+   * neighborhood, deduped by node id and edge id. This is what the renderers
+   * draw in 'lazy' mode (instead of currentSnapshot). Starts empty.
+   */
+  workingSet: GraphSnapshot
+  /** Node ids the user has expanded (neighborhood fetched + merged). */
+  expandedNodeIds: string[]
+
+  // Data (full-snapshot path)
   currentSnapshot: GraphSnapshot | null
   snapshotHistory: TimestampedSnapshot[]
   timelineIndex: number
@@ -176,6 +204,26 @@ export interface HCGExplorerState {
   showClusterLegend: boolean
 }
 
+/**
+ * A de-reified neighborhood payload (mirrors the shape of GET
+ * /hcg/neighborhood). Kept structural here so types.ts / graph-processor stay
+ * decoupled from sophia-client; the client's HCGNeighborhood is assignable.
+ */
+export interface NeighborhoodPayload {
+  nodes: Array<{
+    uuid: string
+    name: string
+    type: string
+    properties?: Record<string, unknown>
+  }>
+  edges: Array<{
+    id: string
+    source: string
+    target: string
+    relation: string
+  }>
+}
+
 /** Explorer actions */
 export type HCGExplorerAction =
   | { type: 'SET_VIEW_MODE'; mode: ViewMode }
@@ -192,6 +240,12 @@ export type HCGExplorerAction =
   | { type: 'TOGGLE_FILTER_PANEL' }
   | { type: 'TOGGLE_NODE_DETAILS' }
   | { type: 'TOGGLE_CLUSTER_LEGEND' }
+  // Lazy-load (seed + expand) actions
+  | { type: 'SET_DATA_MODE'; mode: DataMode }
+  /** Merge a neighborhood into the working set, marking `rootId` expanded when set. */
+  | { type: 'MERGE_NEIGHBORHOOD'; neighborhood: NeighborhoodPayload; rootId?: string | null }
+  /** Clear the lazy-load working set and expanded markers (back to empty canvas). */
+  | { type: 'RESET_WORKING_SET' }
 
 /** Props for renderer components */
 export interface RendererProps {
@@ -278,4 +332,12 @@ export const DEFAULT_EMBEDDING_CONFIG: EmbeddingConfig = {
   fields: 'embedding',
   reducer: 'umap',
   targetDimensions: 3,
+}
+
+/** Empty graph snapshot — the lazy-load working set's initial value. */
+export const EMPTY_SNAPSHOT: GraphSnapshot = {
+  entities: [],
+  edges: [],
+  timestamp: '',
+  metadata: {},
 }

--- a/webapp/src/components/hcg-explorer/utils/graph-processor.test.ts
+++ b/webapp/src/components/hcg-explorer/utils/graph-processor.test.ts
@@ -503,6 +503,47 @@ describe('mergeNeighborhood', () => {
     expect(a?.name).toBe('original')
     expect(a?.type).toBe('entity')
   })
+
+  // Defensive: a null working set or a malformed neighborhood (missing arrays
+  // or entries without ids) must degrade gracefully instead of throwing.
+  it('tolerates a null/empty current working set', () => {
+    const payload = makeNeighborhood(
+      [{ uuid: 'a', name: 'A', type: 'entity', properties: {} }],
+      []
+    )
+    const merged = mergeNeighborhood(
+      null as unknown as GraphSnapshot,
+      payload
+    )
+    expect(merged.entities).toHaveLength(1)
+    expect(merged.edges).toHaveLength(0)
+  })
+
+  it('tolerates a payload missing its nodes/edges arrays', () => {
+    const merged = mergeNeighborhood(
+      EMPTY_SNAPSHOT,
+      {} as unknown as NeighborhoodPayload
+    )
+    expect(merged.entities).toHaveLength(0)
+    expect(merged.edges).toHaveLength(0)
+    expect(merged.metadata).toMatchObject({ entity_count: 0, edge_count: 0 })
+  })
+
+  it('skips payload nodes/edges that lack an id', () => {
+    const payload = {
+      nodes: [
+        { uuid: 'a', name: 'A', type: 'entity', properties: {} },
+        { name: 'no-uuid', type: 'entity', properties: {} },
+      ],
+      edges: [
+        { id: 'e1', source: 'a', target: 'a', relation: 'SELF' },
+        { source: 'a', target: 'a', relation: 'NO_ID' },
+      ],
+    } as unknown as NeighborhoodPayload
+    const merged = mergeNeighborhood(EMPTY_SNAPSHOT, payload)
+    expect(merged.entities.map(e => e.id)).toEqual(['a'])
+    expect(merged.edges.map(e => e.id)).toEqual(['e1'])
+  })
 })
 
 describe('processGraph expanded marker', () => {

--- a/webapp/src/components/hcg-explorer/utils/graph-processor.test.ts
+++ b/webapp/src/components/hcg-explorer/utils/graph-processor.test.ts
@@ -3,8 +3,23 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { processGraph, buildGraph, isEntityTypeDef, isEdgeTypeDef } from './graph-processor'
-import type { GraphSnapshot, FilterConfig, Entity, CausalEdge } from '../types'
+import {
+  processGraph,
+  buildGraph,
+  isEntityTypeDef,
+  isEdgeTypeDef,
+  mergeNeighborhood,
+  neighborhoodNodeToEntity,
+  neighborhoodEdgeToCausalEdge,
+} from './graph-processor'
+import type {
+  GraphSnapshot,
+  FilterConfig,
+  Entity,
+  CausalEdge,
+  NeighborhoodPayload,
+} from '../types'
+import { EMPTY_SNAPSHOT } from '../types'
 
 const createMockSnapshot = (): GraphSnapshot => ({
   entities: [
@@ -371,5 +386,166 @@ describe('faithful views (logical vs reified)', () => {
     const to = g.edges.find(e => e.id === 'e1__to')
     expect(from).toMatchObject({ source: 'e1', target: 'n1', type: 'FROM' })
     expect(to).toMatchObject({ source: 'e1', target: 'u-typedef', type: 'TO' })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Lazy-load (seed + expand): neighborhood mapping + working-set merge/dedupe
+// ---------------------------------------------------------------------------
+
+const makeNeighborhood = (
+  nodes: NeighborhoodPayload['nodes'],
+  edges: NeighborhoodPayload['edges']
+): NeighborhoodPayload => ({ nodes, edges })
+
+describe('neighborhood mapping', () => {
+  it('maps a neighborhood node (uuid -> Entity.id) preserving name/type', () => {
+    const entity = neighborhoodNodeToEntity({
+      uuid: 'u-1',
+      name: 'social plant',
+      type: 'entity',
+      properties: { created: '2026-06-19T00:00:00Z', confidence: 0.7 },
+    })
+    expect(entity.id).toBe('u-1')
+    expect(entity.name).toBe('social plant')
+    expect(entity.type).toBe('entity')
+    expect(entity.labels).toEqual(['entity'])
+    expect(entity.created_at).toBe('2026-06-19T00:00:00Z')
+    expect(entity.properties.confidence).toBe(0.7)
+  })
+
+  it('tolerates a node with no properties', () => {
+    const entity = neighborhoodNodeToEntity({ uuid: 'u-2', name: 'x', type: 'concept' })
+    expect(entity.properties).toEqual({})
+    expect(entity.created_at).toBeUndefined()
+  })
+
+  it('maps a de-reified logical edge (relation -> edge_type) 1:1', () => {
+    const edge = neighborhoodEdgeToCausalEdge({
+      id: 'e-1',
+      source: 'a',
+      target: 'b',
+      relation: 'IS_A',
+    })
+    expect(edge).toMatchObject({
+      id: 'e-1',
+      source_id: 'a',
+      target_id: 'b',
+      edge_type: 'IS_A',
+    })
+  })
+})
+
+describe('mergeNeighborhood', () => {
+  it('seeds an empty working set with a neighborhood', () => {
+    const payload = makeNeighborhood(
+      [
+        { uuid: 'a', name: 'A', type: 'entity', properties: {} },
+        { uuid: 'b', name: 'B', type: 'concept', properties: {} },
+      ],
+      [{ id: 'e1', source: 'a', target: 'b', relation: 'IS_A' }]
+    )
+    const merged = mergeNeighborhood(EMPTY_SNAPSHOT, payload)
+    expect(merged.entities).toHaveLength(2)
+    expect(merged.edges).toHaveLength(1)
+    expect(merged.metadata).toMatchObject({ entity_count: 2, edge_count: 1 })
+  })
+
+  it('does not mutate the input snapshot (pure merge)', () => {
+    const payload = makeNeighborhood(
+      [{ uuid: 'a', name: 'A', type: 'entity', properties: {} }],
+      []
+    )
+    const before = EMPTY_SNAPSHOT.entities.length
+    mergeNeighborhood(EMPTY_SNAPSHOT, payload)
+    expect(EMPTY_SNAPSHOT.entities.length).toBe(before)
+  })
+
+  it('dedupes nodes by uuid and edges by id across two merges', () => {
+    const first = mergeNeighborhood(
+      EMPTY_SNAPSHOT,
+      makeNeighborhood(
+        [
+          { uuid: 'a', name: 'A', type: 'entity', properties: {} },
+          { uuid: 'b', name: 'B', type: 'entity', properties: {} },
+        ],
+        [{ id: 'e1', source: 'a', target: 'b', relation: 'IS_A' }]
+      )
+    )
+    // Second neighborhood overlaps a/e1 and adds c + e2.
+    const second = mergeNeighborhood(
+      first,
+      makeNeighborhood(
+        [
+          { uuid: 'a', name: 'A', type: 'entity', properties: {} },
+          { uuid: 'c', name: 'C', type: 'entity', properties: {} },
+        ],
+        [
+          { id: 'e1', source: 'a', target: 'b', relation: 'IS_A' },
+          { id: 'e2', source: 'a', target: 'c', relation: 'RELATED_TO' },
+        ]
+      )
+    )
+    expect(second.entities.map(e => e.id).sort()).toEqual(['a', 'b', 'c'])
+    expect(second.edges.map(e => e.id).sort()).toEqual(['e1', 'e2'])
+  })
+
+  it('first occurrence wins for a duplicate node id', () => {
+    const first = mergeNeighborhood(
+      EMPTY_SNAPSHOT,
+      makeNeighborhood([{ uuid: 'a', name: 'original', type: 'entity', properties: {} }], [])
+    )
+    const second = mergeNeighborhood(
+      first,
+      makeNeighborhood([{ uuid: 'a', name: 'changed', type: 'concept', properties: {} }], [])
+    )
+    const a = second.entities.find(e => e.id === 'a')
+    expect(a?.name).toBe('original')
+    expect(a?.type).toBe('entity')
+  })
+})
+
+describe('processGraph expanded marker', () => {
+  const lazyFilter: FilterConfig = { ...defaultFilter, skeletonOnly: false }
+
+  it('marks nodes in expandedNodeIds as expanded', () => {
+    const snapshot = mergeNeighborhood(
+      EMPTY_SNAPSHOT,
+      makeNeighborhood(
+        [
+          { uuid: 'a', name: 'A', type: 'entity', properties: {} },
+          { uuid: 'b', name: 'B', type: 'entity', properties: {} },
+        ],
+        []
+      )
+    )
+    const g = processGraph(snapshot, lazyFilter, null, new Set(['a']))
+    expect(g.nodes.find(n => n.id === 'a')?.expanded).toBe(true)
+    expect(g.nodes.find(n => n.id === 'b')?.expanded).toBeUndefined()
+  })
+
+  it('leaves nodes unmarked when no expanded set is given (back-compat)', () => {
+    const snapshot = mergeNeighborhood(
+      EMPTY_SNAPSHOT,
+      makeNeighborhood([{ uuid: 'a', name: 'A', type: 'entity', properties: {} }], [])
+    )
+    const g = processGraph(snapshot, lazyFilter)
+    expect(g.nodes[0].expanded).toBeUndefined()
+  })
+
+  it('buildGraph threads expanded ids through the logical view', () => {
+    const snapshot = mergeNeighborhood(
+      EMPTY_SNAPSHOT,
+      makeNeighborhood(
+        [
+          { uuid: 'a', name: 'A', type: 'entity', properties: {} },
+          { uuid: 'b', name: 'B', type: 'entity', properties: {} },
+        ],
+        [{ id: 'e1', source: 'a', target: 'b', relation: 'RELATED_TO' }]
+      )
+    )
+    const g = buildGraph(snapshot, 'logical', lazyFilter, new Set(['b']))
+    expect(g.nodes.find(n => n.id === 'b')?.expanded).toBe(true)
+    expect(g.nodes.find(n => n.id === 'a')?.expanded).toBeUndefined()
   })
 })

--- a/webapp/src/components/hcg-explorer/utils/graph-processor.ts
+++ b/webapp/src/components/hcg-explorer/utils/graph-processor.ts
@@ -13,8 +13,99 @@ import type {
   ProcessedGraph,
   FilterConfig,
   ClusterAssignment,
+  NeighborhoodPayload,
 } from '../types'
 import { NODE_COLORS } from '../types'
+
+// ---------------------------------------------------------------------------
+// Lazy-load (seed + expand): mapping a de-reified neighborhood into the
+// internal snapshot shape, and merging neighborhoods into an accumulated
+// working set with dedupe (nodes by id, edges by id).
+// ---------------------------------------------------------------------------
+
+/**
+ * Map one de-reified neighborhood node (uuid/name/type/properties) to the
+ * internal Entity shape the render pipeline consumes. The neighborhood's
+ * `uuid` becomes the Entity `id` (renderers key on id), and `name`/`type`
+ * carry through. created_at is read from properties when present.
+ */
+export function neighborhoodNodeToEntity(n: {
+  uuid: string
+  name: string
+  type: string
+  properties?: Record<string, unknown>
+}): Entity {
+  const props = n.properties ?? {}
+  const createdAt =
+    typeof props.created === 'string'
+      ? (props.created as string)
+      : typeof props.created_at === 'string'
+        ? (props.created_at as string)
+        : undefined
+  return {
+    id: n.uuid,
+    type: n.type,
+    name: n.name,
+    properties: props,
+    labels: [n.type],
+    created_at: createdAt,
+  }
+}
+
+/**
+ * Map one de-reified logical edge (id/source/target/relation) to the internal
+ * CausalEdge shape. The endpoint already collapses reified edges to direct
+ * src --relation--> tgt links, so `relation` becomes `edge_type` 1:1.
+ */
+export function neighborhoodEdgeToCausalEdge(e: {
+  id: string
+  source: string
+  target: string
+  relation: string
+}): CausalEdge {
+  return {
+    id: e.id,
+    source_id: e.source,
+    target_id: e.target,
+    edge_type: e.relation,
+    properties: {},
+    weight: 1,
+    created_at: '',
+  }
+}
+
+/**
+ * Merge a de-reified neighborhood into an accumulated working-set snapshot,
+ * returning a NEW snapshot (pure — never mutates the input). Nodes are deduped
+ * by id and edges by id: an incoming node/edge that already exists is dropped
+ * (first occurrence wins, so seeded data is stable across re-expansion). The
+ * timestamp is refreshed and metadata carries running counts.
+ */
+export function mergeNeighborhood(
+  current: GraphSnapshot,
+  payload: NeighborhoodPayload
+): GraphSnapshot {
+  const nodeById = new Map<string, Entity>()
+  for (const e of current.entities) nodeById.set(e.id, e)
+  for (const n of payload.nodes) {
+    if (!nodeById.has(n.uuid)) nodeById.set(n.uuid, neighborhoodNodeToEntity(n))
+  }
+
+  const edgeById = new Map<string, CausalEdge>()
+  for (const e of current.edges) edgeById.set(e.id, e)
+  for (const e of payload.edges) {
+    if (!edgeById.has(e.id)) edgeById.set(e.id, neighborhoodEdgeToCausalEdge(e))
+  }
+
+  const entities = Array.from(nodeById.values())
+  const edges = Array.from(edgeById.values())
+  return {
+    entities,
+    edges,
+    timestamp: new Date().toISOString(),
+    metadata: { entity_count: entities.length, edge_count: edges.length },
+  }
+}
 
 /**
  * How to render the HCG.
@@ -110,7 +201,8 @@ export function toReifiedSnapshot(snapshot: GraphSnapshot): GraphSnapshot {
 export function buildGraph(
   snapshot: GraphSnapshot,
   mode: GraphMode,
-  filterConfig: FilterConfig
+  filterConfig: FilterConfig,
+  expandedNodeIds?: Set<string> | null
 ): ProcessedGraph {
   const transformed =
     mode === 'reified' ? toReifiedSnapshot(snapshot) : toLogicalSnapshot(snapshot)
@@ -127,7 +219,7 @@ export function buildGraph(
   const typeMemberIds = restrict
     ? computeTypeMemberIds(snapshot, filterConfig.selectedTypeId ?? null)
     : null
-  return processGraph(transformed, filterConfig, typeMemberIds)
+  return processGraph(transformed, filterConfig, typeMemberIds, expandedNodeIds)
 }
 
 /** A flat (non-hierarchical) summary of one emergent/ontology type. */
@@ -225,10 +317,16 @@ export function computeHighlightSubgraphIds(
 export function processGraph(
   snapshot: GraphSnapshot,
   filterConfig: FilterConfig,
-  typeMemberIds?: Set<string> | null
+  typeMemberIds?: Set<string> | null,
+  expandedNodeIds?: Set<string> | null
 ): ProcessedGraph {
-  // Convert entities to nodes
-  let nodes = snapshot.entities.map(entityToNode)
+  // Convert entities to nodes, marking those the user has expanded so the
+  // renderers can flag explored nodes in the lazy-load working set.
+  let nodes = snapshot.entities.map(e =>
+    expandedNodeIds && expandedNodeIds.has(e.id)
+      ? { ...entityToNode(e), expanded: true }
+      : entityToNode(e)
+  )
 
   // Convert edges
   let edges = snapshot.edges.map(edgeToGraphEdge)

--- a/webapp/src/components/hcg-explorer/utils/graph-processor.ts
+++ b/webapp/src/components/hcg-explorer/utils/graph-processor.ts
@@ -85,16 +85,27 @@ export function mergeNeighborhood(
   current: GraphSnapshot,
   payload: NeighborhoodPayload
 ): GraphSnapshot {
+  // Defensive: tolerate a null/partial working set or a malformed payload
+  // (missing nodes/edges arrays, or entries without an id/uuid) so a bad API
+  // response degrades to "merge what's valid" instead of throwing.
   const nodeById = new Map<string, Entity>()
-  for (const e of current.entities) nodeById.set(e.id, e)
-  for (const n of payload.nodes) {
-    if (!nodeById.has(n.uuid)) nodeById.set(n.uuid, neighborhoodNodeToEntity(n))
+  for (const e of current?.entities ?? []) {
+    if (e?.id) nodeById.set(e.id, e)
+  }
+  for (const n of payload?.nodes ?? []) {
+    if (n?.uuid && !nodeById.has(n.uuid)) {
+      nodeById.set(n.uuid, neighborhoodNodeToEntity(n))
+    }
   }
 
   const edgeById = new Map<string, CausalEdge>()
-  for (const e of current.edges) edgeById.set(e.id, e)
-  for (const e of payload.edges) {
-    if (!edgeById.has(e.id)) edgeById.set(e.id, neighborhoodEdgeToCausalEdge(e))
+  for (const e of current?.edges ?? []) {
+    if (e?.id) edgeById.set(e.id, e)
+  }
+  for (const e of payload?.edges ?? []) {
+    if (e?.id && !edgeById.has(e.id)) {
+      edgeById.set(e.id, neighborhoodEdgeToCausalEdge(e))
+    }
   }
 
   const entities = Array.from(nodeById.values())

--- a/webapp/src/hooks/__tests__/useHCG.test.tsx
+++ b/webapp/src/hooks/__tests__/useHCG.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * Tests for the lazy-load HCG hooks, focused on the seed-search debounce and
+ * the null/undefined-tolerant query term (review follow-ups).
+ */
+
+import { renderHook, act } from '@testing-library/react'
+import {
+  describe,
+  expect,
+  it,
+  vi,
+  beforeEach,
+  afterEach,
+} from 'vitest'
+import type { ReactNode } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+import { useHCGSearch, HCG_SEARCH_DEBOUNCE_MS } from '../useHCG'
+import { sophiaClient } from '../../lib/sophia-client'
+
+const searchSpy = vi.spyOn(sophiaClient, 'searchHCG')
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  )
+}
+
+describe('useHCGSearch', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    searchSpy.mockReset()
+    searchSpy.mockResolvedValue({
+      success: true,
+      data: [{ uuid: 'u-1', name: 'hit', type: 'entity' }],
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('does not issue a request until the query has been stable for the debounce', async () => {
+    const wrapper = makeWrapper()
+    const { rerender } = renderHook(({ q }: { q: string }) => useHCGSearch(q), {
+      wrapper,
+      initialProps: { q: 'e' },
+    })
+
+    // Simulate fast typing: each keystroke re-renders with a longer query
+    // before the debounce elapses.
+    rerender({ q: 'en' })
+    rerender({ q: 'ent' })
+    rerender({ q: 'enti' })
+    rerender({ q: 'entit' })
+    rerender({ q: 'entity' })
+
+    // Mid-typing (before the debounce window): no request yet.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(HCG_SEARCH_DEBOUNCE_MS - 50)
+    })
+    expect(searchSpy).not.toHaveBeenCalled()
+
+    // Once typing settles past the debounce, exactly one request fires for the
+    // final term -- not one per keystroke.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100)
+    })
+    expect(searchSpy).toHaveBeenCalledTimes(1)
+    expect(searchSpy).toHaveBeenCalledWith('entity', 20)
+  })
+
+  it('never issues a request for an empty or whitespace query', () => {
+    const wrapper = makeWrapper()
+    renderHook(() => useHCGSearch('   '), { wrapper })
+    act(() => {
+      vi.advanceTimersByTime(HCG_SEARCH_DEBOUNCE_MS + 100)
+    })
+    expect(searchSpy).not.toHaveBeenCalled()
+  })
+
+  it('tolerates a null/undefined query without throwing', () => {
+    const wrapper = makeWrapper()
+    expect(() => {
+      renderHook(() => useHCGSearch(null), { wrapper })
+      renderHook(() => useHCGSearch(undefined), { wrapper })
+    }).not.toThrow()
+    act(() => {
+      vi.advanceTimersByTime(HCG_SEARCH_DEBOUNCE_MS + 100)
+    })
+    expect(searchSpy).not.toHaveBeenCalled()
+  })
+})

--- a/webapp/src/hooks/useHCG.ts
+++ b/webapp/src/hooks/useHCG.ts
@@ -4,6 +4,7 @@
  * These hooks call Sophia's API endpoints via sophia-client.
  */
 
+import { useEffect, useState } from 'react'
 import { useQuery, UseQueryResult } from '@tanstack/react-query'
 import { sophiaClient } from '../lib/sophia-client'
 import type {
@@ -199,7 +200,11 @@ export function useHCGNeighborhood(
   return useQuery({
     queryKey: ['hcg', 'neighborhood', uuid, depth, limit],
     queryFn: async () => {
-      const response = await sophiaClient.getHCGNeighborhood(uuid as string, depth, limit)
+      // The enabled-guard below normally prevents this from running without a
+      // uuid, but guard explicitly so a stale/forced fetch surfaces a clear
+      // error instead of building a request against `/hcg/neighborhood/null`.
+      if (!uuid) throw new Error('useHCGNeighborhood: uuid is required')
+      const response = await sophiaClient.getHCGNeighborhood(uuid, depth, limit)
       return unwrapResponse(response)
     },
     staleTime: 30000,
@@ -207,24 +212,43 @@ export function useHCGNeighborhood(
   })
 }
 
+/** Debounce interval (ms) for the seed search query. */
+export const HCG_SEARCH_DEBOUNCE_MS = 300
+
 /**
- * Hook to search HCG nodes for seeding. Enabled only when the query is
- * non-empty (the enabled-guard doubles as the debounce: an empty box issues
- * no request). Callers should pass an already-trimmed query.
+ * Hook to search HCG nodes for seeding.
+ *
+ * The query term is debounced ({@link HCG_SEARCH_DEBOUNCE_MS}) before it reaches
+ * react-query, so typing "entity" issues a single request once typing settles
+ * rather than one per keystroke. The enabled-guard additionally suppresses
+ * requests for an empty/blank query. `q` is tolerant of null/undefined.
  */
 export function useHCGSearch(
-  q: string,
+  q: string | null | undefined,
   limit: number = 20
 ): UseQueryResult<HCGSearchResult[], Error> {
-  const query = q.trim()
+  const query = (q ?? '').trim()
+
+  // Debounce: only let the query reach react-query once it has been stable for
+  // HCG_SEARCH_DEBOUNCE_MS. The debounced value starts empty and is only ever
+  // advanced by the timer, so even the first non-empty term waits out the
+  // window -- each keystroke resets the timer, so the queryKey (and therefore
+  // the request) only changes after typing pauses.
+  const [debouncedQuery, setDebouncedQuery] = useState('')
+  useEffect(() => {
+    if (query === debouncedQuery) return
+    const id = setTimeout(() => setDebouncedQuery(query), HCG_SEARCH_DEBOUNCE_MS)
+    return () => clearTimeout(id)
+  }, [query, debouncedQuery])
+
   return useQuery({
-    queryKey: ['hcg', 'search', query, limit],
+    queryKey: ['hcg', 'search', debouncedQuery, limit],
     queryFn: async () => {
-      const response = await sophiaClient.searchHCG(query, limit)
+      const response = await sophiaClient.searchHCG(debouncedQuery, limit)
       return unwrapResponse(response)
     },
     staleTime: 5000,
-    enabled: query.length > 0,
+    enabled: debouncedQuery.length > 0,
   })
 }
 

--- a/webapp/src/hooks/useHCG.ts
+++ b/webapp/src/hooks/useHCG.ts
@@ -114,6 +114,12 @@ export interface GraphSnapshotOptions {
    * ~3MB of float data on every refetch.
    */
   includeEmbeddings?: boolean
+  /**
+   * Gate the (potentially large) snapshot fetch. Defaults to true to preserve
+   * existing callers; the lazy-load explorer sets this false so the full-graph
+   * query only fires once the user opts into "Load full graph".
+   */
+  enabled?: boolean
 }
 
 export function useHCGSnapshot(
@@ -124,6 +130,7 @@ export function useHCGSnapshot(
     limit = 200,
     refetchInterval,
     includeEmbeddings = true,
+    enabled = true,
   } = options
   return useQuery({
     // includeEmbeddings is part of the key so toggling it never serves a
@@ -139,6 +146,7 @@ export function useHCGSnapshot(
     },
     staleTime: 5000,
     refetchInterval,
+    enabled,
   })
 }
 

--- a/webapp/src/hooks/useHCG.ts
+++ b/webapp/src/hooks/useHCG.ts
@@ -13,11 +13,24 @@ import type {
   HCGEntity,
   HCGEdge,
   HCGGraphSnapshot,
+  HCGStats,
+  HCGTypeSummary,
+  HCGNeighborhood,
+  HCGSearchResult,
 } from '../lib/sophia-client'
 import type { Process, PlanHistory } from '../types/hcg'
 
 // Re-export types for consumers
-export type { PersonaEntryFull, HCGEntity, HCGEdge, HCGGraphSnapshot }
+export type {
+  PersonaEntryFull,
+  HCGEntity,
+  HCGEdge,
+  HCGGraphSnapshot,
+  HCGStats,
+  HCGTypeSummary,
+  HCGNeighborhood,
+  HCGSearchResult,
+}
 
 /**
  * Helper to unwrap sophia-client response and throw on error.
@@ -126,6 +139,84 @@ export function useHCGSnapshot(
     },
     staleTime: 5000,
     refetchInterval,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// HCG scoped / lazy-load hooks (seed + expand)
+//
+// These back the lazy-load explorer: stats for the header, the type layer for
+// entry chips, search for seeding, and neighborhood for on-demand expansion.
+// ---------------------------------------------------------------------------
+
+/**
+ * Hook to fetch headline HCG statistics (counts + typing coverage).
+ */
+export function useHCGStats(): UseQueryResult<HCGStats, Error> {
+  return useQuery({
+    queryKey: ['hcg', 'stats'],
+    queryFn: async () => {
+      const response = await sophiaClient.getHCGStats()
+      return unwrapResponse(response)
+    },
+    staleTime: 10000,
+  })
+}
+
+/**
+ * Hook to fetch the positional type layer (entry chips for seeding).
+ */
+export function useHCGTypes(
+  limit: number = 50
+): UseQueryResult<HCGTypeSummary[], Error> {
+  return useQuery({
+    queryKey: ['hcg', 'types', limit],
+    queryFn: async () => {
+      const response = await sophiaClient.getHCGTypes(limit)
+      return unwrapResponse(response)
+    },
+    staleTime: 30000,
+  })
+}
+
+/**
+ * Hook to fetch the de-reified neighborhood of a node, enabled only when a
+ * uuid is provided (so it never fires for the empty initial canvas).
+ */
+export function useHCGNeighborhood(
+  uuid: string | null | undefined,
+  depth: number = 1,
+  limit: number = 50
+): UseQueryResult<HCGNeighborhood, Error> {
+  return useQuery({
+    queryKey: ['hcg', 'neighborhood', uuid, depth, limit],
+    queryFn: async () => {
+      const response = await sophiaClient.getHCGNeighborhood(uuid as string, depth, limit)
+      return unwrapResponse(response)
+    },
+    staleTime: 30000,
+    enabled: !!uuid,
+  })
+}
+
+/**
+ * Hook to search HCG nodes for seeding. Enabled only when the query is
+ * non-empty (the enabled-guard doubles as the debounce: an empty box issues
+ * no request). Callers should pass an already-trimmed query.
+ */
+export function useHCGSearch(
+  q: string,
+  limit: number = 20
+): UseQueryResult<HCGSearchResult[], Error> {
+  const query = q.trim()
+  return useQuery({
+    queryKey: ['hcg', 'search', query, limit],
+    queryFn: async () => {
+      const response = await sophiaClient.searchHCG(query, limit)
+      return unwrapResponse(response)
+    },
+    staleTime: 5000,
+    enabled: query.length > 0,
   })
 }
 

--- a/webapp/src/lib/sophia-client.ts
+++ b/webapp/src/lib/sophia-client.ts
@@ -848,6 +848,76 @@ export class SophiaClient {
     })
   }
 
+  // ---------------------------------------------------------------------------
+  // HCG scoped / lazy-load methods (seed + expand)
+  //
+  // The explorer no longer loads the whole graph by default. These endpoints
+  // let it start empty and grow an accumulated working set on demand:
+  //   - getHCGStats   -> headline counts + typing coverage for the header
+  //   - getHCGTypes   -> the positional type layer (entry chips)
+  //   - searchHCG     -> seed candidates the user clicks to plant a node
+  //   - getHCGNeighborhood -> 1-hop (or deeper) de-reified expansion of a node
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Get headline HCG statistics: node/edge counts, typing coverage and the
+   * realm / top-predicate breakdowns. Backs the explorer header.
+   */
+  async getHCGStats(): Promise<SophiaResponse<HCGStats>> {
+    return this.performRequest<HCGStats>({
+      action: 'fetching HCG stats',
+      method: 'GET',
+      path: '/hcg/stats',
+    })
+  }
+
+  /**
+   * Get the positional type layer: type-definition nodes with their member
+   * counts and parent type. Used as entry chips for seeding the explorer.
+   */
+  async getHCGTypes(limit: number = 50): Promise<SophiaResponse<HCGTypeSummary[]>> {
+    return this.performRequest<HCGTypeSummary[]>({
+      action: 'fetching HCG types',
+      method: 'GET',
+      path: '/hcg/types',
+      params: { limit: String(limit) },
+    })
+  }
+
+  /**
+   * Get the de-reified neighborhood around a node: the node plus everything
+   * within `depth` hops, with logical edges (src --relation--> tgt). This is
+   * the unit of lazy expansion the explorer merges into its working set.
+   */
+  async getHCGNeighborhood(
+    uuid: string,
+    depth: number = 1,
+    limit: number = 50
+  ): Promise<SophiaResponse<HCGNeighborhood>> {
+    return this.performRequest<HCGNeighborhood>({
+      action: 'fetching HCG neighborhood',
+      method: 'GET',
+      path: `/hcg/neighborhood/${encodeURIComponent(uuid)}`,
+      params: { depth: String(depth), limit: String(limit) },
+    })
+  }
+
+  /**
+   * Search HCG nodes by name/text. Returns lightweight hits the explorer uses
+   * as seed candidates (clicking one plants its neighborhood).
+   */
+  async searchHCG(
+    q: string,
+    limit: number = 20
+  ): Promise<SophiaResponse<HCGSearchResult[]>> {
+    return this.performRequest<HCGSearchResult[]>({
+      action: 'searching HCG',
+      method: 'GET',
+      path: '/hcg/search',
+      params: { q, limit: String(limit) },
+    })
+  }
+
   /**
    * Check HCG endpoint health.
    */
@@ -1101,6 +1171,72 @@ export interface HCGGraphSnapshot {
   timestamp?: string
   /** Additional metadata (optional for HCG snapshots) */
   metadata?: Record<string, unknown>
+}
+
+// ---------------------------------------------------------------------------
+// HCG scoped / lazy-load response types (seed + expand)
+// ---------------------------------------------------------------------------
+
+/** Headline HCG statistics from GET /hcg/stats. */
+export interface HCGStats {
+  total_nodes: number
+  content_nodes: number
+  edge_nodes: number
+  type_definitions: number
+  content_classified: number
+  content_parked: number
+  /** node count per realm / type, e.g. { entity: 2109, process: 94, ... } */
+  by_realm: Record<string, number>
+  /** edge count per predicate, e.g. { IS_A: 2276, INCLUDES: 152, ... } */
+  top_predicates: Record<string, number>
+}
+
+/** One entry of the positional type layer from GET /hcg/types. */
+export interface HCGTypeSummary {
+  uuid: string
+  name: string
+  member_count: number
+  /** parent type name in the IS_A hierarchy (may be a root like "node") */
+  parent: string | null
+}
+
+/** A de-reified neighborhood node from GET /hcg/neighborhood. */
+export interface HCGNeighborhoodNode {
+  uuid: string
+  name: string
+  type: string
+  properties: Record<string, unknown>
+}
+
+/** A de-reified logical edge (src --relation--> tgt) from GET /hcg/neighborhood. */
+export interface HCGNeighborhoodEdge {
+  id: string
+  source: string
+  target: string
+  relation: string
+}
+
+/** Metadata block returned alongside a neighborhood. */
+export interface HCGNeighborhoodMetadata {
+  root: string
+  depth: number
+  reified: boolean
+  node_count: number
+  edge_count: number
+}
+
+/** Response of GET /hcg/neighborhood/{uuid}. */
+export interface HCGNeighborhood {
+  nodes: HCGNeighborhoodNode[]
+  edges: HCGNeighborhoodEdge[]
+  metadata: HCGNeighborhoodMetadata
+}
+
+/** A lightweight search hit from GET /hcg/search. */
+export interface HCGSearchResult {
+  uuid: string
+  name: string
+  type: string
 }
 
 export type {


### PR DESCRIPTION
## Summary

Migrates the HCG Explorer from loading the full graph snapshot to a **lazy-load (seed + expand)** model, so it can explore a huge graph without loading it all. Closes part of #197.

The canvas now starts **empty** and grows an **accumulated working set** on demand. The legacy whole-snapshot path is preserved behind an explicit "Load full graph" toggle (small graphs / back-compat) but is no longer the default.

## Seed + expand model

A new seedbar sits above the existing toolbar:

- **Stats header** (`useHCGStats` -> `GET /hcg/stats`): total nodes, typing coverage (classified / content), type count.
- **Seed search** (`useHCGSearch` -> `GET /hcg/search`): type a query; clicking a result plants that node plus its depth-1 neighborhood. The enabled-guard doubles as a debounce (empty box issues no request).
- **Type chips** (`useHCGTypes` -> `GET /hcg/types`): one-click seeds for the positional type layer.
- **Expand on demand**: select a node, then **Expand neighborhood** in the detail panel fetches its neighborhood (`useHCGNeighborhood` -> `GET /hcg/neighborhood/{uuid}?depth=1`) and merges it in. Expanded nodes are marked (`GraphNode.expanded`) and visually flagged by both the Cytoscape and Three renderers.
- **Working-set counts** (nodes/edges) + **Reset** (clear back to empty).
- **Load full graph** toggle: the snapshot query is gated (`enabled: false`) in lazy mode so it never fires by default.

## Working-set merge / dedupe

`mergeNeighborhood(current, payload)` in `graph-processor.ts` is **pure** (never mutates input):

- Nodes deduped by id, edges deduped by id; **first occurrence wins**, so seeded data is stable across re-expansion.
- Maps the **de-reified** neighborhood shape (`{uuid,name,type,properties}` nodes, `{id,source,target,relation}` edges) into the internal `Entity` / `CausalEdge` render model the renderers already consume (`relation` -> `edge_type` 1:1; no reified edge-nodes).

The context reducer accumulates the working set + expanded ids. The renderers draw `activeSnapshot = workingSet` (lazy) or `currentSnapshot` (full). Endpoint errors surface as a non-blocking banner and never crash the canvas. All existing multi-modal features (2D/3D, layouts, filtering, Types panel, detail panel, density controls) operate over the working set unchanged.

## Scope / compatibility

- Client + hook additions are **purely additive**; other snapshot consumers (`GraphViewer`, `HCGGraph`) are untouched.
- Explorer changes are scoped to the `hcg-explorer` module.

## Tests / build

- `npm run build` (tsc strict + vite): pass
- `npm run lint` (eslint, max-warnings 0): pass
- `npm test` (vitest): **201 passed** (179 existing + 22 new)
- New tests cover: client methods (mocked fetch), `mergeNeighborhood` map/dedupe + `expanded` marker, and the seed/expand/reset context reducer.

## Manual verification (live sophia)

Drove the explorer against running sophia (`localhost:47000`) via Playwright: header showed 7,006 nodes / 965-of-2,313 typed / 16 types; seed search returned live hits; seeding "Plan: Blue Block to Bin" then expanding the `entity` type chip grew the working set to **61 nodes / 59 edges** with **0 console errors**.

## Runtime dependency

Requires the sophia `/hcg/*` scoped endpoints (stats / types / neighborhood / search) from sophia #227 to be live.

https://claude.ai/code/session_01YbGTE3BmHaRBNmJRZbF2oA